### PR TITLE
Use string for the X-Request-Id header

### DIFF
--- a/talisker/request_id.py
+++ b/talisker/request_id.py
@@ -92,7 +92,6 @@ class RequestIdMiddleware(object):
         self.app = app
         self.header = header
         self.wsgi_header = 'HTTP_' + header.upper().replace('-', '_')
-        self.wsgi_header = self.wsgi_header.encode('utf8')
 
     def __call__(self, environ, start_response):
         if self.wsgi_header not in environ:

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -53,7 +53,7 @@ REQUEST_ID = 'X-Request-Id'
 
 def test_middleware_with_id(environ, id):
     middleware = request_id.RequestIdMiddleware(app)
-    environ[b'HTTP_X_REQUEST_ID'] = id
+    environ['HTTP_X_REQUEST_ID'] = id
     body, status, headers = run_wsgi(middleware, environ)
     assert list(set(body)) == [id]
     assert ('X-Request-Id', id) in headers
@@ -70,7 +70,7 @@ def test_middleware_without_id(environ, id):
 
 def test_middleware_alt_header(environ, id):
     middleware = request_id.RequestIdMiddleware(app, 'X-Alternate')
-    environ[b'HTTP_X_ALTERNATE'] = id
+    environ['HTTP_X_ALTERNATE'] = id
     body, status, headers = run_wsgi(middleware, environ)
     assert list(set(body)) == [id]
     assert ('X-Alternate', id) in headers


### PR DESCRIPTION
1) This follows PEP 3333: https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
2) Having the X-Request-Id as bytes causes werkzeug to blow with a TypeError when iterating on available headers at this specific point: https://github.com/pallets/werkzeug/blob/master/werkzeug/datastructures.py#L1349

Local runs are also triggering unrelated errors but I haven't time to check those yet: http://paste.ubuntu.com/23216632/