### PR TITLE
Dummy statsd

### DIFF
--- a/talisker/statsd.py
+++ b/talisker/statsd.py
@@ -82,7 +82,8 @@ class DummyClient(StatsClientBase):
 
     # pipeline methods
     def send(self):
-        self.stats[:] = []
+        if self.stats:
+            self.stats[:] = []
 
     def __enter__(self):
         return self

--- a/talisker/statsd.py
+++ b/talisker/statsd.py
@@ -24,8 +24,11 @@ standard_library.install_aliases()
 from builtins import *  # noqa
 
 import os
+from contextlib import contextmanager
 from urllib.parse import urlparse, parse_qs
-from statsd import StatsClient, defaults
+
+from statsd import defaults
+from statsd.client import StatsClientBase, PipelineBase
 
 __all__ = ['get_client']
 
@@ -52,7 +55,7 @@ def get_client(dsn=None):
         if dsn is None:
             dsn = os.environ.get('STATSD_DSN', None)
         if dsn is None:
-            _client = DummyClient()
+            _client = DummyClient().pipeline()
         else:
             if not dsn.startswith('udp'):
                 raise Exception('Talisker only supports udp stastd client')
@@ -61,6 +64,38 @@ def get_client(dsn=None):
     return _client
 
 
-class DummyClient(StatsClient):
-    def _after(self, stat):
-        pass
+class DummyClient(StatsClientBase):
+    _prefix = ''
+
+    def __init__(self, collect=False):
+        if collect:
+            self.stats = []
+        else:
+            self.stats = None
+
+    def _send(self, data):
+        if self.stats is not None:
+            self.stats.append(data)
+
+    def pipeline(self):
+        return self.__class__(collect=True)
+
+    # pipeline methods
+    def send(self):
+        self.stats.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, typ, value, tb):
+        self.send()
+
+    # test helper methods
+    @contextmanager
+    def collect(self):
+        orig_stats = self.stats
+        self.stats = []
+        yield self.stats
+        self.stats = orig_stats
+
+

--- a/talisker/statsd.py
+++ b/talisker/statsd.py
@@ -82,7 +82,7 @@ class DummyClient(StatsClientBase):
 
     # pipeline methods
     def send(self):
-        self.stats.clear()
+        self.stats[:] = []
 
     def __enter__(self):
         return self

--- a/talisker/statsd.py
+++ b/talisker/statsd.py
@@ -55,7 +55,7 @@ def get_client(dsn=None):
         if dsn is None:
             dsn = os.environ.get('STATSD_DSN', None)
         if dsn is None:
-            _client = DummyClient().pipeline()
+            _client = DummyClient()
         else:
             if not dsn.startswith('udp'):
                 raise Exception('Talisker only supports udp stastd client')

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -199,10 +199,13 @@ def test_error(client):
                    environ_overrides={'REMOTE_ADDR': b'127.0.0.1'})
 
 
-def test_metric(client):
-    pipeline = talisker.statsd.get_client().pipeline()
-    env = {'statsd': pipeline,
+def test_metric(client, metrics):
+    client = talisker.statsd.get_client()
+    env = {'statsd': client,
            'REMOTE_ADDR': b'127.0.0.1'}
-    response = client.get('/_status/metric', environ_overrides=env)
+
+    with client.collect() as stats:
+        response = client.get('/_status/metric', environ_overrides=env)
+        assert stats[0] == 'test:1|c'
+
     assert response.status_code == 200
-    assert pipeline._stats[0] == 'test:1|c'

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -200,11 +200,11 @@ def test_error(client):
 
 
 def test_metric(client, metrics):
-    client = talisker.statsd.get_client()
-    env = {'statsd': client,
+    statsd = talisker.statsd.get_client()
+    env = {'statsd': statsd,
            'REMOTE_ADDR': b'127.0.0.1'}
 
-    with client.collect() as stats:
+    with statsd.collect() as stats:
         response = client.get('/_status/metric', environ_overrides=env)
         assert stats[0] == 'test:1|c'
 

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -45,3 +45,66 @@ def test_parse_statsd_dsn_size():
 def test_parse_statsd_dsn_ipv6():
     parsed = statsd.parse_statsd_dsn('udp6://test.com')
     assert parsed == ('test.com', 8125, None, 512, True)
+
+
+def test_dummyclient_basic(no_network):
+    client = statsd.DummyClient()
+
+    # check the basic methods don't error or use network
+    client.incr('a')
+    client.decr('a')
+    client.timing('a', 1)
+    client.gauge('a', 1)
+    client.set('a', 1)
+    timer = client.timer('a')
+    timer.start()
+    timer.stop()
+
+
+def test_dummyclient_pipeline(no_network):
+    client = statsd.DummyClient()
+    with client.pipeline() as p:
+        p.incr('a')
+        p.decr('a')
+        p.timing('a', 1)
+        p.gauge('a', 1)
+        p.set('a', 1)
+        timer = p.timer('a')
+        timer.start()
+        timer.stop()
+
+        assert p.stats[0] == 'a:1|c'
+        assert p.stats[1] == 'a:-1|c'
+        assert p.stats[2] == 'a:1.000000|ms'
+        assert p.stats[3] == 'a:1|g'
+        assert p.stats[4] == 'a:1|s'
+        assert p.stats[5].startswith('a:')
+        assert p.stats[5].endswith('|ms')
+
+
+def test_dummyclient_nested_pipeline(no_network):
+    client = statsd.DummyClient()
+    with client.pipeline() as p1:
+        with p1.pipeline() as p2:
+            assert p1.stats is not p2.stats
+
+
+def test_dummyclient_collect(no_network):
+    client = statsd.DummyClient()
+    with client.collect() as stats:
+        client.incr('a')
+        client.decr('a')
+        client.timing('a', 1)
+        client.gauge('a', 1)
+        client.set('a', 1)
+        timer = client.timer('a')
+        timer.start()
+        timer.stop()
+
+        assert stats[0] == 'a:1|c'
+        assert stats[1] == 'a:-1|c'
+        assert stats[2] == 'a:1.000000|ms'
+        assert stats[3] == 'a:1|g'
+        assert stats[4] == 'a:1|s'
+        assert stats[5].startswith('a:')
+        assert stats[5].endswith('|ms')

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -115,12 +115,3 @@ def test_dummyclient_collect(no_network):
 def test_no_network(no_network):
     import socket
     socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-
-
-def test_dummyclient_memory(no_network):
-    client = statsd.DummyClient()
-    assert client.stats is None
-    for i in range(1000):
-        client.incr('a')
-    assert client.stats is None
-

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -14,6 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import pytest
 from talisker import statsd
 
 
@@ -108,3 +109,18 @@ def test_dummyclient_collect(no_network):
         assert stats[4] == 'a:1|s'
         assert stats[5].startswith('a:')
         assert stats[5].endswith('|ms')
+
+
+@pytest.mark.xfail
+def test_no_network(no_network):
+    import socket
+    socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+
+def test_dummyclient_memory(no_network):
+    client = statsd.DummyClient()
+    assert client.stats is None
+    for i in range(1000):
+        client.incr('a')
+    assert client.stats is None
+


### PR DESCRIPTION
 Refactor statsd DummyClient for testing

```
 - doesn't create a socket anymore
 - acts as both a statsd client and a pipeline
 - collect() helper method to collect metrics for testing
```
