### PR TITLE
Make the root logger a StructuredLogger

### DIFF
--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -113,10 +113,9 @@ class GunicornLogger(gstatsd.Statsd):
 
     @classmethod
     def install(cls):
-        # in case used as a library, rather than via the entrypoint,
         # install the logger globally, as this is the earliest point we can do
         # so, if not using the talisker entry point
-        logging.setLoggerClass(logs.StructuredLogger)
+        logs._set_logger_class()
 
     def gauge(self, name, value):
         self.statsd.gauge(name, value)

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -21,8 +21,6 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
-import os
-from datetime import datetime
 import logging
 from collections import OrderedDict
 

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -76,8 +76,10 @@ def add_talisker_handler(level, handler, formatter=None):
 
 
 def _set_logger_class():
+    logging.root = ROOT
+    logging.Logger.root = ROOT
+    logging.Logger.manager.root = ROOT
     logging.setLoggerClass(StructuredLogger)
-    logging.getLogger().setLevel(logging.NOTSET)
 
 
 def parse_environ(environ):
@@ -234,6 +236,8 @@ class StructuredLogger(logging.Logger):
         # store extra explicitly for StructuredFormatter to use
         record._structured = structured
         return record
+
+ROOT = StructuredLogger('root', logging.NOTSET)
 
 
 class StructuredFormatter(logging.Formatter):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,8 @@ def clean_up_context():
     logs.StructuredLogger._extra = OrderedDict()
     logs._logging_configured = False
     logging.getLogger().handlers = []
+    if logs.ORIGINAL_ROOT:
+        logs._set_root_logger(logs.ORIGINAL_ROOT)
 
 
 @pytest.fixture

--- a/tests/server.py
+++ b/tests/server.py
@@ -28,7 +28,7 @@ def application(environ, start_response):
     start_response(status, [('content-type', 'text/plain')])
     output = pprint.pformat(environ)
     logging.debug('debug')
-    logging.info('info')
+    logging.info('info', extra={'foo': 'bar'})
     logging.warning('warning')
     logging.error('error')
     logging.critical('critical')

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -307,3 +307,17 @@ def test_parse_environ():
     assert parse({'DEVEL': 1}) == (True, None)
     assert parse({'DEBUGLOG': '/tmp/log'}) == (False, '/tmp/log')
     assert parse({'DEVEL': 1, 'DEBUGLOG': '/tmp/log'}) == (True, '/tmp/log')
+
+
+def test_deferred_logger_defers(log):
+    logger1 = logs.getDeferredLogger('test1')
+    logger2 = logs.getDeferredLogger('test2')
+    logger1.info('1')
+    logger2.info('2')
+    assert len(log) == 0
+    logs.DeferredLogger.enable_logging()
+    assert len(log) == 2
+    logger1.info('3')
+    assert len(log) == 3
+    logger2.info('4')
+    assert len(log) == 4

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -45,6 +45,12 @@ def record_args(msg='msg here'):
     return ('name', logging.INFO, 'fn', 'lno', msg, tuple(), None)
 
 
+def test_root_logger():
+    logs.configure_logging()
+    root = logging.getLogger()
+    assert isinstance(root, logs.StructuredLogger)
+
+
 def make_record(extra, msg='msg here'):
     """Make a test record from StructuredLogger."""
     logger = logs.StructuredLogger('test')


### PR DESCRIPTION
Discovered that tags were not working if you logged directly to the root logger. It's an uncommon case, but it's a wart. So fixed it by replacing the logging module global root object with a StructuredLogger. This is not nice, but it's impossible to do anything else, given logging's design.