### PR TITLE
Use celery signals to set request id automatically

### DIFF
--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -215,7 +215,7 @@ class TaliskerApplication(WSGIApplication):
 
 def run():
     devel = talisker.initialise()
-    talisker.celery.enable_metrics()
+    talisker.celery.enable_signals()
     app = TaliskerApplication(
         "%(prog)s [OPTIONS] [APP_MODULE]", devel)
     return app.run()

--- a/talisker/request_context.py
+++ b/talisker/request_context.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
-from werkzeug.local import LocalManager
+from werkzeug.local import LocalManager, release_local
 
 from talisker.util import context_local
 
@@ -29,4 +29,9 @@ from talisker.util import context_local
 # storage, but if greenlets are being used, it will be a greenlet local.
 request_context = context_local()
 
+
 manager = LocalManager(request_context)
+
+
+def clear():
+    release_local(request_context)

--- a/talisker/request_id.py
+++ b/talisker/request_id.py
@@ -53,8 +53,12 @@ def get():
 
 def set(id):
     """Sets id in both general request context, and specific logging dict"""
-    request_context.request_id = id
-    set_logging_context(request_id=id)
+    if id is None:
+        del request_context.request_id
+        request_context.extra.pop('request_id'), None
+    else:
+        request_context.request_id = id
+        set_logging_context(request_id=id)
 
 
 @contextmanager

--- a/talisker/request_id.py
+++ b/talisker/request_id.py
@@ -54,8 +54,10 @@ def get():
 def set(id):
     """Sets id in both general request context, and specific logging dict"""
     if id is None:
-        del request_context.request_id
-        request_context.extra.pop('request_id'), None
+        if hasattr(request_context, 'request_id'):
+            del request_context.request_id
+        if hasattr(request_context, 'extra'):
+            request_context.extra.pop('request_id', None)
     else:
         request_context.request_id = id
         set_logging_context(request_id=id)

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -94,3 +94,13 @@ def test_context_existing_id(id):
     with request_id.context(id):
         assert request_id.get() == id
     assert request_id.get() == 'existing'
+
+
+def test_set():
+    assert request_id.get() is None
+    request_id.set(None)
+    assert request_id.get() is None
+    request_id.set('id')
+    assert request_id.get() == 'id'
+    request_id.set(None)
+    assert request_id.get() is None


### PR DESCRIPTION
Also, use task headers rather than thread local for celery enqueue metrics