### PR TITLE
Fix #59 - make celery work with 3.1.x again

### DIFF
--- a/requirements.tests.txt
+++ b/requirements.tests.txt
@@ -6,3 +6,5 @@ blinker>=1.4,<2.0
 pytest-cov>=2.3.1
 prometheus-client==0.0.17
 django>=1.10
+celerytest
+sqlalchemy

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ test = pytest
 
 [flake8]
 exclude = .*,env,lib,dist,build,tests/django_app
+ignore = E402
 
 [tool:pytest]
 testpaths = tests docs

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     install_requires=install_requires,
     extras_require={
-        'celery': ["celery>=3.1.0"],
+        'celery': ["celery>=3.1.13,<5.0"],
         'prometheus': ["prometheus-client==0.0.17"],
         'flask': ["flask>=0.11,<0.12", "blinker>=1.4,<2.0"],
     },

--- a/talisker/endpoints.py
+++ b/talisker/endpoints.py
@@ -81,9 +81,9 @@ def private(f):
             return f(self, request)
         else:
             msg = PRIVATE_BODY_RESPONSE_TEMPLATE.format(
-                    ip_str,
-                    force_unicode(request.remote_addr),
-                    request.headers.get('x-forwarded-for'))
+                ip_str,
+                force_unicode(request.remote_addr),
+                request.headers.get('x-forwarded-for'))
             return Response(msg, status='403')
     return wrapper
 

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -35,7 +35,7 @@ __all__ = [
     'get_session',
     'configure',
     'enable_requests_logging',
-    ]
+]
 
 HEADER = to_native_string(request_id.HEADER)
 storage = threading.local()

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -35,7 +35,7 @@ def test_talisker_client_defaults(monkeypatch, log):
     monkeypatch.setitem(os.environ, 'TALISKER_DOMAIN', 'example.com')
 
     client = talisker.sentry.get_client.uncached(
-            dsn=conftest.DSN, transport=conftest.DummyTransport)
+        dsn=conftest.DSN, transport=conftest.DummyTransport)
 
     assert 'configured raven' in log[-1].msg
 


### PR DESCRIPTION
Make celery signal handlers now work in both 3.1.x and 4.0.x again

Rework celery tests to use actual broker (in memory). The
tests/celery_app.py functional tests still use redis.

Fixed flake8 checks, so some small lint clean ups too.