### PR TITLE
Fix celery metrics with eager tasks

### DIFF
--- a/talisker/celery.py
+++ b/talisker/celery.py
@@ -57,6 +57,7 @@ def _protected_counter(name):
         if not hasattr(sender, attr):
             stat_name = 'celery.{}.{}'.format(sender.name, name)
             talisker.statsd.get_client().incr(stat_name)
+            setattr(sender, attr, True)
     return protected_signal
 
 

--- a/talisker/celery.py
+++ b/talisker/celery.py
@@ -49,7 +49,7 @@ def _counter(name):
 def _protected_counter(name):
     """Count metrics, but ensure only once.
 
-    This is needed when tasks are eagerly invoked and have reties, or else
+    This is needed when tasks are eagerly invoked and have retries, or else
     metrics will be duplicated."""
     attr = '_talisker_sent_' + name
 

--- a/tests/celery_app.py
+++ b/tests/celery_app.py
@@ -39,7 +39,7 @@ def job_b(self):
     try:
         raise Exception('failed task')
     except Exception:
-        self.retry(countdown=1, max_retries=3)
+        self.retry(countdown=1, max_retries=2)
 
 
 if __name__ == '__main__':
@@ -64,4 +64,5 @@ if __name__ == '__main__':
     logger.info('started job b with id c')
     job.revoke()
     logger.info('revoked job b')
+    job_b.apply()
     logger.info('done')

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -49,7 +49,7 @@ def before_task_publish(sender, body, headers, **kwargs):
 
 # make task run always take 2s
 def task_prerun(sender, task_id, task, **kwargs):
-    task.talisker_timer._start_time -= 2.0
+    task.talisker_timestamp -= 2.0
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR fixes an issue with celery statsd metrics when the task is run synchronously/eagerly. It does so firstly by switching to raw timestamps rather than statsd.Timer objects, which fail when hit twice. It also changes the logic to cope with signal ordering in eager task execution, as in the presence of retries is very differerent from async tasks.

For a task that retries twice before failing, in async execution the signal order is

prerun
<task>
postrun
task_retry
prerun
<task retry 1>
postrun
task_retry
prerun
<task retry 2>
task_failure
postrun


However, if task is apply() synchronously/eagerly, the retry is recursive, and so it looks like this

prerun
<task>
prerun
<recursive task>
prerun
<recursive task>
task_failure
postrun
task_failure
postrun
task_failure
postrun

This pr adjusts the celery signal handlers that generate metrics to cope with both cases.