### PR TITLE
Add option to disable log colouring.

### DIFF
--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -24,6 +24,7 @@ from builtins import *  # noqa
 from collections import OrderedDict
 import logging
 import logging.handlers
+import os
 import sys
 import time
 
@@ -102,7 +103,7 @@ def configure(config):  # pragma: no cover
     set_logger_class()
     formatter = StructuredFormatter()
     # note: we recheck isatty, incase devel mode has been forced with DEVEL=1
-    if sys.stderr.isatty():
+    if sys.stderr.isatty() and 'TALISKER_NO_COLOR' not in os.environ:
         formatter = ColoredFormatter()
 
     # always INFO to stderr


### PR DESCRIPTION
This fixes #77 - the workaround mentioned there (piping talisker though 'cat' in the upstart job config) breaks the upstart job, so we need a workaround pretty quickly. 

I've proposed adding a new environment variable: `TALISKER_NO_COLOR` - when present in talisker environment, the coloured log formatter will not be configured.

I couldn't find any tests for the talisker logs, but let me know if you think this needs automated tests.