### PR TITLE
Refactor devel and colored output

### DIFF
--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -54,10 +54,12 @@ ACTIVE = set(['true', '1', 'yes'])
 def get_config(env=os.environ):
     """Load talisker config from environment"""
     devel = env.get('DEVEL', '').lower() in ACTIVE
-    if 'TALISKER_COLOR' in env:
-        color = env.get('TALISKER_COLOR', '').lower() in ACTIVE
-    else:
-        color = devel and sys.stderr.isatty()
+    color = False
+    if devel:
+        if 'TALISKER_COLOR' in env:
+            color = env.get('TALISKER_COLOR', '').lower() in ACTIVE
+        else:
+            color = sys.stderr.isatty()
 
     return {
         'devel': devel,

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -54,12 +54,15 @@ ACTIVE = set(['true', '1', 'yes'])
 def get_config(env=os.environ):
     """Load talisker config from environment"""
     devel = env.get('DEVEL', '').lower() in ACTIVE
+    if 'TALISKER_COLOR' in env:
+        color = env.get('TALISKER_COLOR', '').lower() in ACTIVE
+    else:
+        color = devel and sys.stderr.isatty()
+
     return {
         'devel': devel,
+        'color': color,
         'debuglog': env.get('DEBUGLOG'),
-        'color': (
-            devel and sys.stderr.isatty() and 'TALISKER_NO_COLOR' not in env
-        ),
     }
 
 

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -53,9 +53,13 @@ ACTIVE = set(['true', '1', 'yes'])
 
 def get_config(env=os.environ):
     """Load talisker config from environment"""
+    devel = env.get('DEVEL', '').lower() in ACTIVE
     return {
+        'devel': devel,
         'debuglog': env.get('DEBUGLOG'),
-        'devel': env.get('DEVEL', '').lower() in ACTIVE,
+        'color': (
+            devel and sys.stderr.isatty() and 'TALISKER_NO_COLOR' not in env
+        ),
     }
 
 

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -48,11 +48,14 @@ def initialise(env=os.environ):
     return config
 
 
+ACTIVE = set(['true', '1', 'yes'])
+
+
 def get_config(env=os.environ):
     """Load talisker config from environment"""
     return {
         'debuglog': env.get('DEBUGLOG'),
-        'devel': sys.stderr.isatty() or 'DEVEL' in env,
+        'devel': env.get('DEVEL', '').lower() in ACTIVE,
     }
 
 

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -24,7 +24,6 @@ from builtins import *  # noqa
 import logging
 import os
 import tempfile
-import sys
 from collections import OrderedDict
 
 from gunicorn.glogging import Logger
@@ -222,9 +221,7 @@ class TaliskerApplication(WSGIApplication):
         if self.cfg.loglevel.lower() == 'debug' and self._devel:
             # user has configured debug level logging
             self.cfg.set('loglevel', 'DEBUG')
-            # only echo to stderr if we are in interactive mode
-            if sys.stderr.isatty():
-                logs.enable_debug_log_stderr()
+            logs.enable_debug_log_stderr()
 
         # ensure gunicorn sends debug level messages when needed
         if self._debuglog:

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -219,7 +219,7 @@ class TaliskerApplication(WSGIApplication):
                 extra={'errorlog': self.cfg.errorlog})
             self.cfg.set('errorlog', '-')
 
-        if self.cfg.loglevel.lower() == 'debug':
+        if self.cfg.loglevel.lower() == 'debug' and self._devel:
             # user has configured debug level logging
             self.cfg.set('loglevel', 'DEBUG')
             # only echo to stderr if we are in interactive mode

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -101,8 +101,7 @@ def configure(config):  # pragma: no cover
 
     set_logger_class()
     formatter = StructuredFormatter()
-    # note: we recheck isatty, incase devel mode has been forced with DEVEL=1
-    if config['devel'] and sys.stderr.isatty():
+    if config['color']:
         formatter = ColoredFormatter()
 
     # always INFO to stderr

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -102,7 +102,7 @@ def configure(config):  # pragma: no cover
     set_logger_class()
     formatter = StructuredFormatter()
     # note: we recheck isatty, incase devel mode has been forced with DEVEL=1
-    if sys.stderr.isatty():
+    if config['devel'] and sys.stderr.isatty():
         formatter = ColoredFormatter()
 
     # always INFO to stderr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ def config():
     return {
         'devel': False,
         'debuglog': None,
+        'color': False,
     }
 
 

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -193,7 +193,6 @@ def test_gunicorn_application_config_loglevel_debug_devel(monkeypatch, log):
     monkeypatch.setattr(
         sys, 'argv',
         ['talisker', 'wsgi:app', '--log-level', 'debug'])
-    monkeypatch.setattr(sys.stderr, 'isatty', lambda: True)
     app = gunicorn.TaliskerApplication('', devel=True)
     assert app.cfg.loglevel.lower() == 'debug'
     assert logs.get_talisker_handler().level == logging.DEBUG

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -158,6 +158,8 @@ def test_gunicorn_application_init(monkeypatch):
     monkeypatch.setattr(sys, 'argv', ['talisker', 'wsgi:app'])
     app = gunicorn.TaliskerApplication('')
     assert app.cfg.logger_class == gunicorn.GunicornLogger
+    assert app.cfg.loglevel.lower() == 'info'
+    assert logs.get_talisker_handler().level == logging.NOTSET
 
 
 def test_gunicorn_application_init_devel(monkeypatch):
@@ -193,7 +195,7 @@ def test_gunicorn_application_config_loglevel_debug_devel(monkeypatch, log):
         ['talisker', 'wsgi:app', '--log-level', 'debug'])
     monkeypatch.setattr(sys.stderr, 'isatty', lambda: True)
     app = gunicorn.TaliskerApplication('', devel=True)
-    assert app.cfg.loglevel == 'DEBUG'
+    assert app.cfg.loglevel.lower() == 'debug'
     assert logs.get_talisker_handler().level == logging.DEBUG
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,6 +39,7 @@ def test_get_config(monkeypatch):
         devel=True,
         color=True,
     )
+    assert_config({'TALISKER_COLOR': '1'}, devel=False, color=False)
     monkeypatch.setattr(sys.stderr, 'isatty', lambda: True)
     assert_config({'DEVEL': '1'}, devel=True, color=True)
     assert_config(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,9 +24,9 @@ import sys
 import talisker
 
 
-def assert_config(env, **kwargs):
+def assert_config(env, **expected):
     cfg = talisker.get_config(env)
-    for k, v in kwargs.items():
+    for k, v in expected.items():
         assert cfg[k] == v
 
 
@@ -34,10 +34,15 @@ def test_get_config(monkeypatch):
     assert_config({}, devel=False, debuglog=None, color=False)
     assert_config({'DEVEL': '1'}, devel=True)
     assert_config({'DEBUGLOG': '/tmp/log'}, debuglog='/tmp/log')
+    assert_config(
+        {'DEVEL': '1', 'TALISKER_COLOR': '1'},
+        devel=True,
+        color=True,
+    )
     monkeypatch.setattr(sys.stderr, 'isatty', lambda: True)
     assert_config({'DEVEL': '1'}, devel=True, color=True)
     assert_config(
-        {'DEVEL': '1', 'TALISKER_NO_COLOR': 1},
+        {'DEVEL': '1', 'TALISKER_COLOR': '0'},
         devel=True,
         color=False,
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,21 +20,18 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import *  # noqa
-import sys
 import talisker
 
 
 def test_get_config(monkeypatch):
     parse = talisker.get_config
     assert parse({}) == {'devel': False, 'debuglog': None}
-    assert parse({'DEVEL': 1}) == {'devel': True, 'debuglog': None}
+    assert parse({'DEVEL': '1'}) == {'devel': True, 'debuglog': None}
     assert parse({'DEBUGLOG': '/tmp/log'}) == {
         'devel': False,
         'debuglog': '/tmp/log'
     }
-    assert parse({'DEVEL': 1, 'DEBUGLOG': '/tmp/log'}) == {
+    assert parse({'DEVEL': '1', 'DEBUGLOG': '/tmp/log'}) == {
         'devel': True,
         'debuglog': '/tmp/log',
     }
-    monkeypatch.setattr(sys.stderr, 'isatty', lambda: True)
-    assert parse({}) == {'devel': True, 'debuglog': None}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,18 +20,24 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import *  # noqa
+import sys
 import talisker
 
 
+def assert_config(env, **kwargs):
+    cfg = talisker.get_config(env)
+    for k, v in kwargs.items():
+        assert cfg[k] == v
+
+
 def test_get_config(monkeypatch):
-    parse = talisker.get_config
-    assert parse({}) == {'devel': False, 'debuglog': None}
-    assert parse({'DEVEL': '1'}) == {'devel': True, 'debuglog': None}
-    assert parse({'DEBUGLOG': '/tmp/log'}) == {
-        'devel': False,
-        'debuglog': '/tmp/log'
-    }
-    assert parse({'DEVEL': '1', 'DEBUGLOG': '/tmp/log'}) == {
-        'devel': True,
-        'debuglog': '/tmp/log',
-    }
+    assert_config({}, devel=False, debuglog=None, color=False)
+    assert_config({'DEVEL': '1'}, devel=True)
+    assert_config({'DEBUGLOG': '/tmp/log'}, debuglog='/tmp/log')
+    monkeypatch.setattr(sys.stderr, 'isatty', lambda: True)
+    assert_config({'DEVEL': '1'}, devel=True, color=True)
+    assert_config(
+        {'DEVEL': '1', 'TALISKER_NO_COLOR': 1},
+        devel=True,
+        color=False,
+    )

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -307,8 +307,7 @@ def test_configure_debug_log(config, log):
 
 
 def test_configure_colored(config, log, monkeypatch):
-    monkeypatch.setattr(sys.stderr, 'isatty', lambda: True)
-    config['devel'] = True
+    config['color'] = True
     logs.configure(config)
     assert isinstance(
         logs.get_talisker_handler().formatter, logs.ColoredFormatter)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -252,6 +252,8 @@ def assert_output_includes_message(err, msg):
 
 def test_configure(config, capsys):
     logs.configure(config)
+    assert not isinstance(
+        logs.get_talisker_handler().formatter, logs.ColoredFormatter)
     logger = logging.getLogger('test')
     logger.info('test msg')
     out, err = capsys.readouterr()
@@ -302,6 +304,14 @@ def test_configure_debug_log(config, log):
         logger='talisker.logs',
         level='INFO',
         extra={'path': logfile})
+
+
+def test_configure_colored(config, log, monkeypatch):
+    monkeypatch.setattr(sys.stderr, 'isatty', lambda: True)
+    config['devel'] = True
+    logs.configure(config)
+    assert isinstance(
+        logs.get_talisker_handler().formatter, logs.ColoredFormatter)
 
 
 def test_escape_quotes():


### PR DESCRIPTION
This PR:

a) reverts to requiring DEVEL env var to enable colors, as this is safer, and upstart uses ptys, so broke our attempt at detection

b) color can always be disabled by setting TALISKER_NO_COLOR envar

c) allows explicitly disabling devel with DEVEL=False

It also adds a couple of missing tests.

Fixes #77 