### PR TITLE
Fix sentry default config when used with flask

### DIFF
--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -82,15 +82,21 @@ def ensure_talisker_config(kwargs):
             '- talisker manages this')
     kwargs['install_logging_hook'] = False
 
-    kwargs.setdefault('release', talisker.revision.get())
+    # flask integration explictly sets options as None
+    if kwargs.get('release') is None:
+        kwargs['release'] = talisker.revision.get()
     # don't hook libraries by default
-    kwargs.setdefault('hook_libraries', [])
+    if kwargs.get('hook_libraries') is None:
+        kwargs['hook_libraries'] = []
 
     # set from the environment
-    kwargs.setdefault('environment', os.environ.get('TALISKER_ENV'))
+    if kwargs.get('environment') is None:
+        kwargs['environment'] = os.environ.get('TALISKER_ENV')
     # if not set, will default to hostname
-    kwargs.setdefault('name', os.environ.get('TALISKER_UNIT'))
-    kwargs.setdefault('site', os.environ.get('TALISKER_DOMAIN'))
+    if kwargs.get('name') is None:
+        kwargs['name'] = os.environ.get('TALISKER_UNIT')
+    if kwargs.get('site') is None:
+        kwargs['site'] = os.environ.get('TALISKER_DOMAIN')
 
     from_env = False
     dsn = kwargs.get('dsn', None)

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -98,6 +98,42 @@ def test_talisker_client_defaults_none(monkeypatch, log):
     assert data['tags']['site'] == 'example.com'
 
 
+def test_talisker_client_defaults_explicit_config(monkeypatch, log):
+    monkeypatch.setitem(os.environ, 'TALISKER_ENV', 'production')
+    monkeypatch.setitem(os.environ, 'TALISKER_UNIT', 'talisker-1')
+    monkeypatch.setitem(os.environ, 'TALISKER_DOMAIN', 'example.com')
+
+    # raven flask integration passes in all possible kwargs as None
+    kwargs = {
+        'release': 'release',
+        'hook_libraries': ['requests'],
+        'site': 'site',
+        'environment': 'environment',
+        'name': 'name',
+    }
+    client = talisker.sentry.get_client.uncached(
+        dsn=conftest.DSN, transport=conftest.DummyTransport, **kwargs)
+
+    # this is unpleasant, but it saves us mocking
+    assert raven.breadcrumbs.install_logging_hook.called is False
+    assert raven.breadcrumbs._hook_requests.called is True
+    assert raven.breadcrumbs._install_httplib.called is False
+
+    # check message
+    try:
+        raise Exception('test')
+    except:
+        client.captureException()
+
+    messages = conftest.sentry_messages(client)
+    data = messages[0]
+
+    assert data['release'] == 'release'
+    assert data['environment'] == 'environment'
+    assert data['server_name'] == 'name'
+    assert data['tags']['site'] == 'site'
+
+
 def test_log_client(monkeypatch, log):
     dsn = 'http://user:pass@host:8000/app'
     client = raven.Client(dsn)


### PR DESCRIPTION
The sentry flask integration sets all kwargs explcitly as None, so setdefault didn't work. Instead, check explicitly with .get(), with will return None when both a) no kwarg is set and b) flask integration explicitly sets the kwarg to None