### PR TITLE
Clear sentry context on request start

### DIFF
--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -41,6 +41,10 @@ def initialise(env=os.environ):
     import talisker.logs
     talisker.logs.configure(config)
     # now that logging is set up, initialise other modules
+    # sentry first, so we can report any further errors in initialisation
+    # TODO: add deferred logging, so we can set up sentry first thing
+    import talisker.sentry
+    talisker.sentry.get_client()
     import talisker.statsd
     talisker.statsd.get_client()
     import talisker.endpoints

--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -53,6 +53,10 @@ default_processors = set([
 
 sentry_globals = module_dict()
 
+# access logs a generated after a request has finished and the breadcrumb
+# context cleared. This means that they appear in the next requests
+# breadcrumbs, unless we ignore it
+raven.breadcrumbs.ignore_logger('gunicorn.access')
 # sql queries are recorded as breadcrumbs anyway, so don't record them as log
 # queries twice if they happen to be slow
 raven.breadcrumbs.ignore_logger('talisker.slowqueries')

--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -53,7 +53,7 @@ default_processors = set([
 
 sentry_globals = module_dict()
 
-# access logs a generated after a request has finished and the breadcrumb
+# access logs are generated after a request has finished and the breadcrumb
 # context cleared. This means that they appear in the next requests
 # breadcrumbs, unless we ignore it
 raven.breadcrumbs.ignore_logger('gunicorn.access')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ import pytest
 import raven.breadcrumbs
 import raven.transport
 import raven.base
+import raven.context
 
 import talisker.context
 import talisker.logs
@@ -63,6 +64,7 @@ def clean_up():
     talisker.logs.reset_logging()
     # reset context storage
     talisker.context.clear()
+    raven.context._active_contexts.__dict__.clear()
 
 
 @pytest.fixture

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -164,8 +164,8 @@ def test_middleware_clears_context(environ):
 
     mw = talisker.sentry.get_middleware(app)
     context = mw.client.context
-    context.clear()  # clear startup logs
-    assert len(context.breadcrumbs.buffer) == 0
+    logger.info('other log')
+    assert len(context.breadcrumbs.buffer) == 1
     mw(environ, lambda: None)
     assert len(context.breadcrumbs.buffer) == 1
 


### PR DESCRIPTION
Otherwise it bleeds into the request afterwards, which is super confusing