### PR TITLE
Access log cleanups

### DIFF
--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -61,17 +61,11 @@ class GunicornLogger(Logger):
     """Custom gunicorn logger to use structured logging."""
 
     def get_extra(self, resp, req, environ, request_time):
-        status = resp.status
-        if isinstance(status, (str, bytes)):
-            status = status[:3]
-        else:
-            status = str(status)
-
         extra = OrderedDict()
         extra['method'] = environ.get('REQUEST_METHOD')
         extra['path'] = environ.get('PATH_INFO')
         extra['qs'] = environ.get('QUERY_STRING')
-        extra['status'] = status
+        extra['status'] = str(resp.status_code)
         extra['ip'] = environ.get('REMOTE_ADDR', None)
         extra['proto'] = environ.get('SERVER_PROTOCOL')
         extra['length'] = getattr(resp, 'sent', None)
@@ -124,12 +118,10 @@ class GunicornLogger(Logger):
             request_time.seconds * 1000 +
             float(request_time.microseconds) / 10 ** 3
         )
-        status = resp.status
-        if isinstance(status, (str, bytes)):
-            status = int(status.split(None, 1)[0])
         self.histogram("gunicorn.request.duration", duration_in_ms)
         self.increment("gunicorn.requests", 1)
-        self.increment("gunicorn.request.status.{}".format(status), 1)
+        self.increment("gunicorn.request.status.{}".format(
+            resp.status_code), 1)
 
     def setup(self, cfg):
         super(GunicornLogger, self).setup(cfg)
@@ -213,7 +205,7 @@ class TaliskerApplication(WSGIApplication):
 
         # override and warn
         if self.cfg.errorlog != '-':
-            logger.warn(
+            logger.warning(
                 'ignoring gunicorn errorlog config, talisker logs to stderr',
                 extra={'errorlog': self.cfg.errorlog})
             self.cfg.set('errorlog', '-')
@@ -229,7 +221,7 @@ class TaliskerApplication(WSGIApplication):
 
         # override and warn
         if self.cfg.statsd_host or self.cfg.statsd_prefix:
-            logger.warn(
+            logger.warning(
                 'ignoring gunicorn statsd config, as has no effect when '
                 'using talisker, as it uses STATS_DSN env var',
                 extra={'statsd_host': self.cfg.statsd_host,
@@ -239,7 +231,7 @@ class TaliskerApplication(WSGIApplication):
 
         # trust but warn
         if self.cfg.logger_class is not GunicornLogger:
-            logger.warn(
+            logger.warning(
                 'using custom gunicorn logger class - this may break '
                 'Talisker\'s logging configuration',
                 extra={'logger_class': self.cfg.logger_class})

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -89,9 +89,7 @@ class GunicornLogger(Logger):
         if request_id:
             extra['request_id'] = request_id
 
-        msg = "{} {}".format(extra['method'], extra['path'])
-        if extra['qs']:
-            msg += '?'
+        msg = "{method} {path}{0}".format('?' if extra['qs'] else '', **extra)
         return msg, extra
 
     # Log errors and warnings

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -61,12 +61,11 @@ class GunicornLogger(Logger):
     """Custom gunicorn logger to use structured logging."""
 
     def get_extra(self, resp, req, environ, request_time):
-
-        msg = "%s %s" % (environ['REQUEST_METHOD'], environ['RAW_URI'])
-
         status = resp.status
         if isinstance(status, (str, bytes)):
             status = status[:3]
+        else:
+            status = str(status)
 
         extra = OrderedDict()
         extra['method'] = environ.get('REQUEST_METHOD')
@@ -90,6 +89,9 @@ class GunicornLogger(Logger):
         if request_id:
             extra['request_id'] = request_id
 
+        msg = "{} {}".format(extra['method'], extra['path'])
+        if extra['qs']:
+            msg += '?'
         return msg, extra
 
     # Log errors and warnings

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -281,7 +281,7 @@ class StructuredFormatter(logging.Formatter):
         super(StructuredFormatter, self).__init__(fmt, datefmt)
 
     def format(self, record):
-        """Format message, with escaped quotes and structured tags."""
+        """Format message with structured tags and any exception/trailer"""
         record.message = self.clean_message(record.getMessage())
         if len(record.message) > self.MAX_MSG_SIZE:
             record.message = (
@@ -324,7 +324,7 @@ class StructuredFormatter(logging.Formatter):
         return s
 
     def clean_message(self, s):
-        return s.replace('"', '\\"').replace('\n', '')
+        return s.replace('"', '\\"').replace('\n', '\\n')
 
     def remove_quotes(self, s):
         return s.replace('"', '')

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -282,7 +282,7 @@ class StructuredFormatter(logging.Formatter):
 
     def format(self, record):
         """Format message, with escaped quotes and structured tags."""
-        record.message = self.escape_quotes(record.getMessage())
+        record.message = self.clean_message(record.getMessage())
         if len(record.message) > self.MAX_MSG_SIZE:
             record.message = (
                 record.message[:self.MAX_MSG_SIZE] + self.TRUNCATED
@@ -323,8 +323,8 @@ class StructuredFormatter(logging.Formatter):
                                                'replace')
         return s
 
-    def escape_quotes(self, s):
-        return s.replace('"', '\\"')
+    def clean_message(self, s):
+        return s.replace('"', '\\"').replace('\n', '')
 
     def remove_quotes(self, s):
         return s.replace('"', '')

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -122,7 +122,7 @@ def test_gunicorn_logger_access(environ, log, statsd_metrics):
     cfg.set('accesslog', '-')
     logger = gunicorn.GunicornLogger(cfg)
 
-    log.clear()
+    log[:] = []
     logger.access(response, None, environ, delta)
     assert log[0]._structured == expected
     assert log[0].msg == 'GET /'
@@ -139,7 +139,7 @@ def test_gunicorn_logger_access_qs(environ, log):
     cfg.set('accesslog', '-')
     logger = gunicorn.GunicornLogger(cfg)
 
-    log.clear()
+    log[:] = []
     logger.access(response, None, environ, delta)
     assert log[0]._structured == expected
     assert log[0].msg == 'GET /url?'
@@ -155,7 +155,7 @@ def test_gunicorn_logger_access_with_request_id(environ, log):
     cfg.set('accesslog', '-')
     logger = gunicorn.GunicornLogger(cfg)
 
-    log.clear()
+    log[:] = []
     logger.access(response, None, environ, delta)
     assert log[0]._structured == expected
 

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -63,7 +63,8 @@ def test_gunicorn_logger_propagate_error_log():
 
 
 class TestResponse:
-    status = u'200 OK'
+    status_code = 200
+    status = '200 OK'
     sent = 1000
     headers = []
 
@@ -102,28 +103,6 @@ def test_gunicorn_logger_get_extra(environ):
     msg, extra = logger.get_extra(response, None, environ, delta)
     assert msg == 'GET /foo?'
     assert extra == expected
-
-
-def test_gunicorn_logger_get_extra_str_status(environ):
-    response, environ, delta, expected = access_extra_args(
-        environ, '/')
-    cfg = Config()
-    logger = gunicorn.GunicornLogger(cfg)
-    response.status = '200 OK'
-
-    msg, extra = logger.get_extra(response, None, environ, delta)
-    assert extra['status'] == '200'
-
-
-def test_gunicorn_logger_get_extra_int_status(environ):
-    response, environ, delta, expected = access_extra_args(
-        environ, '/')
-    cfg = Config()
-    logger = gunicorn.GunicornLogger(cfg)
-    response.status = 200
-
-    msg, extra = logger.get_extra(response, None, environ, delta)
-    assert extra['status'] == '200'
 
 
 def test_gunicorn_logger_access(environ, log, statsd_metrics):

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -115,6 +115,17 @@ def test_gunicorn_logger_get_extra_str_status(environ):
     assert extra['status'] == '200'
 
 
+def test_gunicorn_logger_get_extra_int_status(environ):
+    response, environ, delta, expected = access_extra_args(
+        environ, '/')
+    cfg = Config()
+    logger = gunicorn.GunicornLogger(cfg)
+    response.status = 200
+
+    msg, extra = logger.get_extra(response, None, environ, delta)
+    assert extra['status'] == '200'
+
+
 def test_gunicorn_logger_access(environ, log, statsd_metrics):
     response, environ, delta, expected = access_extra_args(
         environ, '/')

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -196,7 +196,7 @@ def test_formatter_escapes_quotes():
     assert structured == {'a': 'b'}
 
 
-def test_formatter_strips_newlines():
+def test_formatter_escapes_newlines():
     fmt = logs.StructuredFormatter()
     log = fmt.format(make_record({'a': 'b'}, msg='some \nmessage'))
     timestamp, level, name, msg, structured = parse_logfmt(log)
@@ -204,7 +204,7 @@ def test_formatter_strips_newlines():
     assert level == 'INFO'
     assert name == 'name'
     # check quotes doesn't break parsing
-    assert msg == 'some message'
+    assert msg == 'some \\nmessage'
     assert structured == {'a': 'b'}
 
 
@@ -342,7 +342,7 @@ def test_clean_message():
     assert fmt.clean_message('foo') == 'foo'
     assert fmt.clean_message('foo "bar"') == r'foo \"bar\"'
     assert fmt.clean_message('foo "bar"') == r'foo \"bar\"'
-    assert fmt.clean_message('foo\nbar') == r'foobar'
+    assert fmt.clean_message('foo\nbar') == r'foo\nbar'
 
 
 def test_logfmt_no_value():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -196,6 +196,18 @@ def test_formatter_escapes_quotes():
     assert structured == {'a': 'b'}
 
 
+def test_formatter_strips_newlines():
+    fmt = logs.StructuredFormatter()
+    log = fmt.format(make_record({'a': 'b'}, msg='some \nmessage'))
+    timestamp, level, name, msg, structured = parse_logfmt(log)
+    assert timestamp == TIMESTAMP
+    assert level == 'INFO'
+    assert name == 'name'
+    # check quotes doesn't break parsing
+    assert msg == 'some message'
+    assert structured == {'a': 'b'}
+
+
 def test_formatter_with_extra():
     fmt = logs.StructuredFormatter()
     log = fmt.format(make_record({'foo': 'bar', 'baz': 'with spaces'}))
@@ -325,10 +337,12 @@ def test_configure_colored(config, log, monkeypatch):
         logs.get_talisker_handler().formatter, logs.ColoredFormatter)
 
 
-def test_escape_quotes():
+def test_clean_message():
     fmt = logs.StructuredFormatter()
-    assert fmt.escape_quotes('foo') == 'foo'
-    assert fmt.escape_quotes('foo "bar"') == r'foo \"bar\"'
+    assert fmt.clean_message('foo') == 'foo'
+    assert fmt.clean_message('foo "bar"') == r'foo \"bar\"'
+    assert fmt.clean_message('foo "bar"') == r'foo \"bar\"'
+    assert fmt.clean_message('foo\nbar') == r'foobar'
 
 
 def test_logfmt_no_value():


### PR DESCRIPTION
This strips newlines from the logmsg, as it confuses grok. Also, it doesn't include the querystring in the logmsg for gunicorn's access log, as it can be overly long and is already included in the qs field