### PR TITLE
support the various ways in which gunicorn responses can encode status

### DIFF
--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -72,12 +72,6 @@ class GunicornLogger(Logger):
             return resp.status
 
     def get_extra(self, resp, req, environ, request_time, status):
-
-        if hasattr(resp, 'status_code'):
-            status = resp.status_code
-        else:
-            status = int(resp.status[:3])
-
         extra = OrderedDict()
         extra['method'] = environ.get('REQUEST_METHOD')
         extra['path'] = environ.get('PATH_INFO')

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -99,7 +99,7 @@ def test_gunicorn_logger_get_extra(environ):
         environ, '/foo?bar=baz')
     cfg = Config()
     logger = gunicorn.GunicornLogger(cfg)
-    msg, extra = logger.get_extra(response, None, environ, delta)
+    msg, extra = logger.get_extra(response, None, environ, delta, 200)
     assert msg == 'GET /foo?'
     assert extra == expected
 

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -94,6 +94,23 @@ def access_extra_args(environ, url='/'):
     return response, environ, delta, expected
 
 
+def test_gunicorn_get_response_status():
+    cfg = Config()
+    logger = gunicorn.GunicornLogger(cfg)
+
+    class Response1:
+        status_code = 200
+    assert logger.get_response_status(Response1()) == 200
+
+    class Response2:
+        status = '200 OK'
+    assert logger.get_response_status(Response2()) == 200
+
+    class Response3:
+        status = 200
+    assert logger.get_response_status(Response3()) == 200
+
+
 def test_gunicorn_logger_get_extra(environ):
     response, environ, delta, expected = access_extra_args(
         environ, '/foo?bar=baz')


### PR DESCRIPTION
Different gunicorn worker classes seem to vary how they use status/status_code of the internal gunicorn response object, so handle that more robustly.