### PR TITLE
Add a functional test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ addons:
   addons:
     postgresql: "9.5"
 install: pip install tox
+before_script:
+ - make db-setup
 services:
     - redis-server
 script: make tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,6 @@ addons:
   addons:
     postgresql: "9.5"
 install: pip install tox
+services:
+    - redis-server
 script: make tox

--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,13 @@ _test: $(VENV)
 
 TEST_FILES = $(shell find tests -maxdepth 1 -name test_\*.py  | cut -c 7- | cut -d. -f1)
 $(TEST_FILES):
-	$(BIN)/py.test -k $@ $(ARGS)
+	. $(BIN)/activate && py.test -k $@ $(ARGS)
 
 export DEBUGLOG=log
 export DEVEL=1
 WORKER ?= sync
 PORT ?= 8000
-TALISKER = $(BIN)/talisker --bind 0.0.0.0:$(PORT) --reload --worker-class $(WORKER) $(ARGS)
+TALISKER = $(BIN)/talisker.gunicorn --bind 0.0.0.0:$(PORT) --reload --worker-class $(WORKER) $(ARGS)
 run wsgi:
 	$(TALISKER) tests.wsgi_app:application
 

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,11 @@ flask: | lib/sqlalchemy
 lib/redis:
 	$(BIN)/pip install redis
 
+db-setup:
+	psql -U postgres -c "create database django_app;"
+	psql -U postgres -c "create user django_app with password 'django_app';"
+	psql -U postgres -c "grant all privileges on database django_app to django_app;"
+
 migrate:
 	$(BIN)/python tests/django_app/manage.py migrate
 

--- a/requirements.tests.txt
+++ b/requirements.tests.txt
@@ -5,7 +5,7 @@ pytest-postgresql>=1.3.0
 setuptools>=35.0.0
 
 # for integration tests
-eventlet==0.21.0
+eventlet==0.22.0
 gevent==1.2.2
 redis==2.10.6
 SQLAlchemy==1.1.14

--- a/requirements.tests.txt
+++ b/requirements.tests.txt
@@ -3,5 +3,9 @@ freezegun>=0.3.6
 pytest-cov>=2.3.1
 pytest-postgresql>=1.3.0
 setuptools>=35.0.0
-eventlet
-gevent
+
+# for integration tests
+eventlet==0.21.0
+gevent==1.2.2
+redis==2.10.6
+SQLAlchemy==1.1.14

--- a/talisker/testing.py
+++ b/talisker/testing.py
@@ -219,7 +219,7 @@ class ServerProcess(object):
         if rc is not None and rc > 0:
             raise ServerProcessError('subprocess errored')
 
-    def readline(self, timeout=10, delay=0.1):
+    def readline(self, timeout=30, delay=0.1):
         if not self.output_file.closed:
             self.output_file.flush()
 
@@ -242,10 +242,10 @@ class ServerProcess(object):
     def wait_for_output(self, target, timeout, delay=0.1):
         try:
             if len(self.output) == 0:
-                timeout = self.readline(timeout, delay)
+                self.readline(timeout, delay)
 
             while target not in self.output[-1]:
-                timeout = self.readline(timeout, delay)
+                self.readline(timeout, delay)
 
         except Exception:
             self.close(error=True)

--- a/talisker/testing.py
+++ b/talisker/testing.py
@@ -166,6 +166,7 @@ class ServerProcess(object):
             bufsize=0,
             stdout=self.output_file,
             stderr=subprocess.STDOUT,
+            stdin=subprocess.PIPE,
             universal_newlines=True,
             env=self.env
         )
@@ -187,7 +188,7 @@ class ServerProcess(object):
 
         if not self.reader.closed:
             for line in self.reader.readlines():
-                self.output.append(line)
+                self.output.append(line.strip())
             self.reader.close()
 
         if error:
@@ -241,8 +242,14 @@ class ServerProcess(object):
 
     def wait_for_output(self, target, timeout, delay=0.1):
         try:
+            # read first line if needed
             if len(self.output) == 0:
                 self.readline(timeout, delay)
+
+            # maybe we already got there
+            for line in self.output:
+                if target in line:
+                    return
 
             while target not in self.output[-1]:
                 self.readline(timeout, delay)

--- a/tests/celery_app.py
+++ b/tests/celery_app.py
@@ -27,8 +27,8 @@ import celery
 app = celery.Celery(
     'tests.celery_app',
     broker='redis://localhost:6379',
+    backend='redis://localhost:6379',
 )
-app.conf.result_backend = 'redis://localhost:6379/0'
 logger = logging.getLogger(__name__)
 
 

--- a/tests/celery_app.py
+++ b/tests/celery_app.py
@@ -33,18 +33,18 @@ logger = logging.getLogger(__name__)
 
 
 @app.task(bind=True)
-def job_a(self):
-    logger.info('job a')
-    return 'job a'
+def basic_task(self):
+    logger.info('basic task')
+    return 'basic'
 
 
 @app.task(bind=True)
-def job_b(self):
-    logger.info('job b')
+def error_task(self):
+    logger.info('error task')
     try:
         raise Exception('failed task')
     except Exception:
-        self.retry(countdown=1, max_retries=2)
+        self.retry(countdown=1, max_retries=1)
 
 
 if __name__ == '__main__':
@@ -54,20 +54,20 @@ if __name__ == '__main__':
     talisker.celery.enable_signals()
     logger = logging.getLogger('tests.celery_app')
     logger.info('starting')
-    job_a.delay()
+    basic_task.delay()
     logger.info('started job a')
     with talisker.request_id.context('a'):
-        job_a.delay()
+        basic_task.delay()
     logger.info('started job a with id a')
-    job_a.delay()
+    basic_task.delay()
     logger.info('started job a')
     with talisker.request_id.context('b'):
-        job_b.delay()
+        error_task.delay()
     logger.info('started job b with id b')
     with talisker.request_id.context('c'):
-        job = job_b.delay()
+        job = error_task.delay()
     logger.info('started job b with id c')
     job.revoke()
     logger.info('revoked job b')
-    job_b.apply()
+    error_task.apply()
     logger.info('done')

--- a/tests/celery_app.py
+++ b/tests/celery_app.py
@@ -24,13 +24,18 @@ from builtins import *  # noqa
 import logging
 import celery
 
-app = celery.Celery('tests.celery_app', broker='redis://localhost:6379')
+app = celery.Celery(
+    'tests.celery_app',
+    broker='redis://localhost:6379',
+)
+app.conf.result_backend = 'redis://localhost:6379/0'
 logger = logging.getLogger(__name__)
 
 
 @app.task(bind=True)
 def job_a(self):
     logger.info('job a')
+    return 'job a'
 
 
 @app.task(bind=True)

--- a/tests/django_app/django_app/urls.py
+++ b/tests/django_app/django_app/urls.py
@@ -22,6 +22,7 @@ from django.conf.urls.static import static
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
+    url(r'', views.index),
     url(r'^error/', views.error),
     url(r'^celery/', views.celery),
     url(r'^db/', views.db),

--- a/tests/django_app/django_app/views.py
+++ b/tests/django_app/django_app/views.py
@@ -8,6 +8,10 @@ from django.db import connection
 from django.contrib.auth.models import User, Group
 
 
+def index(request):
+    return HttpResponse('ok', status=200)
+
+
 def error(request):
     User.objects.count()
     Group.objects.count()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -22,8 +22,9 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 import os
 
-import requests
 import pytest
+import requests
+
 from talisker.testing import GunicornProcess, ServerProcess
 from tests.celery_app import basic_task, error_task
 
@@ -67,12 +68,13 @@ def test_celery_basic():
     cmd = ['talisker.celery', 'worker', '-q', '-A', 'tests.celery_app']
 
     with ServerProcess(cmd) as pr:
+        pr.wait_for_output(' ready.')
         result = basic_task.delay()
-        output = result.wait(timeout=2)
+        error_result = error_task.delay()
 
-        #error_result = error_task.delay()
-        #with pytest.raises(Exception):
-        #    error_result.wait(timeout=3)
+        output = result.wait(timeout=3)
+        with pytest.raises(Exception):
+            error_result.wait(timeout=3)
 
     assert output == 'basic'
     assert {

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2016- Canonical Ltd
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+from builtins import *  # noqa
+import os
+
+import requests
+from talisker.testing import GunicornProcess, ServerProcess
+
+APP = 'tests.wsgi_app:application'
+
+
+def test_gunicorn_sync_worker():
+    with GunicornProcess(APP, args=['--worker-class=sync']) as p:
+        response = requests.get(p.url('/'))
+        assert response.status_code == 200
+
+
+def test_gunicorn_gevent_worker():
+    with GunicornProcess(APP, args=['--worker-class=gevent']) as p:
+        response = requests.get(p.url('/'))
+        assert response.status_code == 200
+
+
+def test_gunicorn_eventlet_worker():
+    with GunicornProcess(APP, args=['--worker-class=eventlet']) as p:
+        response = requests.get(p.url('/'))
+        assert response.status_code == 200
+
+
+def test_flask_app():
+    with GunicornProcess('tests.flask_app:app') as p:
+        response = requests.get(p.url('/'))
+        assert response.status_code == 200
+
+
+def test_django_app(monkeypatch):
+    env = os.environ.copy()
+    env['PYTHONPATH'] = 'tests/django_app/'
+    with GunicornProcess(
+            'tests.django_app.django_app.wsgi:application', env=env) as p:
+        response = requests.get(p.url('/'))
+        assert response.status_code == 200
+
+
+def test_celery():
+    cmd = ['talisker.celery', 'worker', '-q', '-A', 'tests.celery_app']
+    from tests.celery_app import job_a, job_b
+    with ServerProcess(cmd) as p:
+        result = job_a.delay()
+        output = result.wait(timeout=2)
+
+    assert output == 'job a'
+    assert {
+        'logmsg': 'job a',
+        'extra': {'task_name': 'tests.celery_app.job_a'},
+    } in p.log

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -66,9 +66,11 @@ def test_django_app(monkeypatch):
 
 def test_celery_basic():
     cmd = ['talisker.celery', 'worker', '-q', '-A', 'tests.celery_app']
+    env = os.environ.copy()
+    env['PYTHONUNBUFFERED'] = '1'
 
-    with ServerProcess(cmd) as pr:
-        pr.wait_for_output(' ready.')
+    with ServerProcess(cmd, env=env) as pr:
+        pr.wait_for_output(' ready.', timeout=10)
         result = basic_task.delay()
         error_result = error_task.delay()
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -20,8 +20,11 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import *  # noqa
+import textwrap
+
 import pytest
 import requests
+
 from talisker import testing
 
 
@@ -60,6 +63,28 @@ def test_serverprocess_failure():
         with server:
             while 1:
                 server.check()
+
+
+def test_serverprocess_output(tmpdir):
+    script = tmpdir.join('script.sh')
+    script.write("for i in $(seq 20); do echo $i; done")
+    server = testing.ServerProcess(['bash', str(script)])
+    with server:
+        server.ps.wait()
+    assert server.output == [str(i) for i in range(1, 21)]
+
+
+def test_serverprocess_output_wait(tmpdir):
+    script = tmpdir.join('script.sh')
+    script.write("echo 1; echo 2; echo 'here'; read; echo 3; echo 4;")
+    server = testing.ServerProcess(['bash', str(script)])
+    with server:
+        server.wait_for_output('here', timeout=5)
+        assert server.output == ['1', '2', 'here']
+        server.ps.stdin.write('bar\n')
+        server.ps.wait()
+
+    assert server.output == ['1', '2', 'here', '3', '4']
 
 
 def test_gunicornprocess_success():

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -67,11 +67,11 @@ def test_gunicornprocess_success():
     gunicorn = testing.GunicornProcess('tests.wsgi_app')
     with gunicorn:
         r = requests.get(gunicorn.url('/'), headers={'X-Request-Id': id})
-        assert r.status_code == 404
+        assert r.status_code == 200
     assert {
         'logmsg': 'GET /',
         'extra': {
-            'status': '404',
+            'status': '200',
             'method': 'GET',
             'ip': '127.0.0.1',
             'proto': 'HTTP/1.1',

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -20,7 +20,6 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import *  # noqa
-import textwrap
 
 import pytest
 import requests

--- a/tests/wsgi_app.py
+++ b/tests/wsgi_app.py
@@ -24,7 +24,10 @@ import logging
 
 
 def application(environ, start_response):
-    status = '404 Not Found'
+    if environ['PATH_INFO'] == '/_status/check':
+        status = '404 Not Found'
+    else:
+        status = '200 OK'
     start_response(status, [('content-type', 'text/plain')])
     output = pprint.pformat(environ)
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
This PR adds a functional test suite, use the talisker.testing helpers added earlier.

I ended up avoiding pipes all together, to many issues with buffering and blocking. Using a temporary files allows for a nice writer fd and a reader fd to process the output without contention, and allows for a timeout by retrying the reader if it returns ''.