### PR TITLE
Requests metrics redux

### DIFF
--- a/docs/requests.rst
+++ b/docs/requests.rst
@@ -36,7 +36,7 @@ the following metric name::
   my.prefix.requests.somehost-com.POST.200
 
 
-You can customised the name of this metric in a few ways. Firstly, if you are
+You can customise the name of this metric in a few ways. Firstly, if you are
 using IP addresses in your urls, you can give them a human friendly name for
 the metric::
 
@@ -48,7 +48,7 @@ Now, a request to http://1.2.3.4/ will emit a metric like so::
 
 Talisker does not include the url path in the metric name by default, as it
 could be highly variable, and thus create too many distinct metrics. But you
-can optionally allow a number of path compontents to be included in the
+can optionally allow a number of path components to be included in the
 name::
 
     session.get('https://somehost.com/some/url/XXX', metrics_path_len=2)

--- a/docs/requests.rst
+++ b/docs/requests.rst
@@ -8,8 +8,8 @@ Requests
 Enhanced session
 ----------------
 
-Talisker provides a way to upgrade a request.Session instance with two main
-extra features.
+Talisker provides a way to upgrade a request.Session instance with a few extra
+features.
 
 Firstly, the X-Request-Id header will be added to the outgoing request headers.
 This can be used by other services to track the originating request id. We
@@ -26,14 +26,36 @@ in the form:::
 
   <prefix>.requests.<hostname>.<method>.<status code>
 
-In the hostname, a '.' is replaced with a '-'. So an http request like this:::
+In the hostname, a '.' is replaced with a '-'. So an http request like this::
 
   session.post('https://somehost.com/some/url', data=...)
 
 would result in the duration of that request in ms being sent to statsd with
-the following metric name:::
+the following metric name::
 
   my.prefix.requests.somehost-com.POST.200
+
+
+You can customised the name of this metric in a few ways. Firstly, if you are
+using IP addresses in your urls, you can give them a human friendly name for
+the metric::
+
+    talisker.requests.register_ip('1.2.3.4', 'myhost')
+
+Now, a request to http://1.2.3.4/ will emit a metric like so::
+
+    my.prefix.requests.myhost.POST.200
+
+Talisker does not include the url path in the metric name by default, as it
+could be highly variable, and thus great too many distint metrics. But you can
+override than, and allow a number of path compontents to be included in the
+name::
+
+    session.get('https://somehost.com/some/url/XXX', metrics_path_len=2)
+
+will output a metric name::
+
+    my.prefix.requests.myhost.some.url.POST.200
 
 
 Session lifecycle
@@ -70,10 +92,11 @@ ensure there is one instance of this session subclass per thread.::
 
 This works because talisker does not subclass Session to add metrics or
 requests id tracing. Instead, it adds a response hook to the session object for
-metrics, and decorates the prepare_request *instance* method to inject the header
-(ugh, but I couldn't find a better way).
+metrics, and decorates the prepare_request *instance* method to inject the
+header (ugh, but I couldn't find a better way).
 
-If you wish to use talisker's enhancements, but not the lifecycle management, you can do::
+If you wish to use talisker's enhancements, but not the lifecycle management,
+you can do::
 
   session = MySession()
   talisker.requests.configure(session)

--- a/docs/requests.rst
+++ b/docs/requests.rst
@@ -47,8 +47,8 @@ Now, a request to http://1.2.3.4/ will emit a metric like so::
     my.prefix.requests.myhost.POST.200
 
 Talisker does not include the url path in the metric name by default, as it
-could be highly variable, and thus great too many distint metrics. But you can
-override than, and allow a number of path compontents to be included in the
+could be highly variable, and thus create too many distinct metrics. But you
+can optionally allow a number of path compontents to be included in the
 name::
 
     session.get('https://somehost.com/some/url/XXX', metrics_path_len=2)
@@ -92,8 +92,8 @@ ensure there is one instance of this session subclass per thread.::
 
 This works because talisker does not subclass Session to add metrics or
 requests id tracing. Instead, it adds a response hook to the session object for
-metrics, and decorates the prepare_request *instance* method to inject the
-header (ugh, but I couldn't find a better way).
+metrics, and decorates the send method to inject the header (ugh, but
+I couldn't find a better way).
 
 If you wish to use talisker's enhancements, but not the lifecycle management,
 you can do::

--- a/requirements.tests.txt
+++ b/requirements.tests.txt
@@ -3,6 +3,7 @@ freezegun>=0.3.6
 pytest-cov>=2.3.1
 pytest-postgresql>=1.3.0
 pytest-xdist>=1.22.0
+responses==0.8.1
 setuptools>=35.0.0
 
 # for integration tests

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -122,13 +122,13 @@ def get_timing(response, path_len=0):
     if path_len > 0:
         path_components = parsed.path.lstrip('/').split('/')
         dotted_path = '.'.join(path_components[:path_len])
-        url = '{}.'.format(dotted_path)
+        url_components = '{}.'.format(dotted_path)
     else:
-        url = ''
+        url_components = ''
 
     prefix = 'requests.{}.{}{}.{}'.format(
         hostname.replace('.', '-'),
-        url,
+        url_components,
         response.request.method.upper(),
         str(response.status_code),
     )

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -34,10 +34,10 @@ from .util import parse_url
 from . import request_id
 
 __all__ = [
-    'HEADER',
-    'get_session',
     'configure',
     'enable_requests_logging',
+    'get_session',
+    'register_ip',
 ]
 
 # wsgi requires native strings

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -15,7 +15,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 from datetime import timedelta
+
+import pytest
 import requests
+import responses
+
 import talisker.requests
 import talisker.statsd
 
@@ -34,24 +38,29 @@ def response(
     return resp
 
 
-def test_get_timing_root():
-    r = response()
-    name, duration = talisker.requests.get_timing(r)
-    assert name == 'requests.example-com.GET.200'
+@pytest.mark.parametrize('resp, expected', [
+    (response(), 'requests.example-com.GET.200'),
+    (response(method='POST'), 'requests.example-com.POST.200'),
+    (response(code=500), 'requests.example-com.GET.500'),
+])
+def test_get_timing_base(resp, expected):
+    name, duration = talisker.requests.get_timing(resp)
+    assert name == expected
     assert duration == 1000.0
 
 
-def test_get_timing_post():
-    r = response(method='POST')
-    name, duration = talisker.requests.get_timing(r)
-    assert name == 'requests.example-com.POST.200'
+def test_get_timing_hostname(monkeypatch):
+    monkeypatch.setitem(talisker.requests.HOSTS, '1.2.3.4', 'myhost.com')
+    resp = response(host='http://1.2.3.4')
+    name, duration = talisker.requests.get_timing(resp)
+    assert name == 'requests.myhost-com.GET.200'
     assert duration == 1000.0
 
 
-def test_get_timing_500():
-    r = response(code=500)
-    name, duration = talisker.requests.get_timing(r)
-    assert name == 'requests.example-com.GET.500'
+def test_get_timing_path_len():
+    resp = response(url='/foo/bar')
+    name, duration = talisker.requests.get_timing(resp, 2)
+    assert name == 'requests.example-com.foo.bar.GET.200'
     assert duration == 1000.0
 
 
@@ -61,12 +70,37 @@ def test_metric_hook(statsd_metrics):
     assert statsd_metrics[0] == 'requests.example-com.GET.200:1000.000000|ms'
 
 
-def test_configure():
+@responses.activate
+def test_configured_session(statsd_metrics):
     session = requests.Session()
     talisker.requests.configure(session)
 
-    req = requests.Request('GET', 'http://localhost')
-    with talisker.request_id.context('XXX'):
-        prepared = session.prepare_request(req)
+    responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
 
-    assert prepared.headers['X-Request-Id'] == 'XXX'
+    with talisker.request_id.context('XXX'):
+        session.get('http://localhost/foo/bar')
+
+    assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
+    assert statsd_metrics[0].startswith('requests.localhost.GET.200:')
+
+
+@responses.activate
+def test_configured_session_with_url_metrics(statsd_metrics):
+    session = requests.Session()
+    talisker.requests.configure(session)
+
+    responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
+
+    with talisker.request_id.context('XXX'):
+        session.get('http://localhost/foo/bar', metric_path_len=1)
+        session.get('http://localhost/foo/bar', metric_path_len=2)
+        session.get('http://localhost/foo/bar')
+
+    assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
+    assert statsd_metrics[0].startswith('requests.localhost.foo.GET.200:')
+
+    assert responses.calls[1].request.headers['X-Request-Id'] == 'XXX'
+    assert statsd_metrics[1].startswith('requests.localhost.foo.bar.GET.200:')
+
+    assert responses.calls[2].request.headers['X-Request-Id'] == 'XXX'
+    assert statsd_metrics[2].startswith('requests.localhost.GET.200:')


### PR DESCRIPTION
Add support for customising metric names for http requests. Can now register a human-friendlt name for an ip, and also specify a number of path components to include in the metric name.

The implementation is a bit hackish, for 2 reasons:

1) we try to avoid requiring subclassing requests.Session and requests.TransportAdaptor, as these are frequently done in user code, and don't compose well. This means we decorate instance attributes at run time. Which does not taste good.

2) Ideally, we'd simply attach ``metric_path_len`` to the request object, and then use it in the response hook. But the request object is created and used directly inside the request function, there's no way we can do that unless we re-implement the entire request function, which could likely break lots of things.

I'd like to propose some changes to requests upstream to make this kind of customisation easier, if I find some time.