### PR TITLE
Request's breadcrumbs and logging

### DIFF
--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -21,11 +21,13 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
+import collections
 import functools
 import logging
 import threading
 
 from future.utils import native
+import raven.breadcrumbs
 import requests
 import werkzeug.local
 
@@ -48,6 +50,7 @@ HOSTS = {}
 
 # storage for metric url state, as requests design allows for no other way
 _local = werkzeug.local.Local()
+logger = logging.getLogger('talisker.requests')
 
 
 def register_ip(ip, name):
@@ -88,7 +91,19 @@ def inject_request_id(func):
         id = request_id.get()
         if id and HEADER not in request.headers:
             request.headers[HEADER] = id
-        return func(request, **kwargs)
+        try:
+            return func(request, **kwargs)
+        except Exception as e:
+            metadata = collect_metadata(request, None)
+            metadata['exception'] = str(e)
+            logger.exception('http request failure', extra=metadata)
+            raven.breadcrumbs.record(
+                type='http',
+                category='requests',
+                data=metadata,
+            )
+            raise
+
     send._inject_request_id = True
     return send
 
@@ -107,17 +122,59 @@ def enable_metric_control(func):
     return request
 
 
+def collect_metadata(request, response):
+    metadata = collections.OrderedDict()
+    metadata['url'] = request.url
+    metadata['method'] = request.method
+
+    if response is not None:
+        metadata['status_code'] = response.status_code
+        duration = response.elapsed.total_seconds() * 1000
+        metadata['duration'] = duration
+
+    request_type = request.headers.get('content-type', None)
+    if request_type is not None:
+        metadata['request_type'] = request_type
+
+    try:
+        metadata['request_size'] = int(
+            request.headers.get('content-length', 0))
+    except ValueError:
+        pass
+
+    if response is not None:
+        response_type = response.headers.get('content-type', None)
+        if response_type is not None:
+            metadata['response_type'] = response_type
+        try:
+            metadata['response_size'] = int(
+                response.headers.get('content-length', 0))
+        except ValueError:
+            pass
+
+    return metadata
+
+
 def metrics_response_hook(response, **kwargs):
-    """Response hook that records statsd metrics"""
-    if getattr(_local, 'emit_metric', True):
-        path_len = getattr(_local, 'metric_path_len', 0)
-        prefix, duration = get_timing(response, path_len)
-        statsd.get_client().timing(prefix, duration)
+    """Response hook that records statsd metrics and breadcrumbs."""
+    try:
+        metadata = collect_metadata(response.request, response)
+        logger.info('http request', extra=metadata)
+
+        # massage breadcrumb data to meet sentry expectations for http request
+        raven.breadcrumbs.record(
+            type='http', category='requests', data=metadata)
+
+        if getattr(_local, 'emit_metric', True):
+            path_len = getattr(_local, 'metric_path_len', 0)
+            metric_name = get_metric_name(response, path_len)
+            statsd.get_client().timing(metric_name, metadata['duration'])
+    except Exception:
+        logging.exception('response hook error')
 
 
-def get_timing(response, path_len=0):
+def get_metric_name(response, path_len=0):
     parsed = parse_url(response.request.url)
-    duration = response.elapsed.total_seconds() * 1000
     if parsed.hostname in HOSTS:
         hostname = HOSTS[parsed.hostname]
     else:
@@ -135,7 +192,7 @@ def get_timing(response, path_len=0):
         response.request.method.upper(),
         str(response.status_code),
     )
-    return prefix, duration
+    return prefix
 
 
 def enable_requests_logging():  # pragma: nocover

--- a/tests/flask_app.py
+++ b/tests/flask_app.py
@@ -29,13 +29,20 @@ conn.execute(select([users]))
 app = Flask(__name__)
 talisker.flask.register(app)
 
+talisker.requests.get_session().post(
+    'http://httpbin.org/post', json={'foo': 'bar'})
+
 
 @app.route('/')
 def index():
+    talisker.requests.get_session().post(
+        'http://httpbin.org/post', json={'foo': 'bar'})
     return 'ok'
 
 
 @app.route('/error/')
 def error():
     conn.execute(select([users]))
+    talisker.requests.get_session().post(
+        'http://httpbin.org/post', json={'foo': 'bar'})
     raise Exception('test')

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -85,6 +85,20 @@ def test_configured_session(statsd_metrics):
 
 
 @responses.activate
+def test_configured_session_disable_metrics(statsd_metrics):
+    session = requests.Session()
+    talisker.requests.configure(session)
+
+    responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
+
+    with talisker.request_id.context('XXX'):
+        session.get('http://localhost/foo/bar', emit_metric=False)
+
+    assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
+    assert len(statsd_metrics) == 0
+
+
+@responses.activate
 def test_configured_session_with_url_metrics(statsd_metrics):
     session = requests.Session()
     talisker.requests.configure(session)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -17,6 +17,7 @@
 from datetime import timedelta
 
 import pytest
+import raven.context
 import requests
 import responses
 
@@ -43,45 +44,76 @@ def response(
     (response(method='POST'), 'requests.example-com.POST.200'),
     (response(code=500), 'requests.example-com.GET.500'),
 ])
-def test_get_timing_base(resp, expected):
-    name, duration = talisker.requests.get_timing(resp)
+def test_get_metric_name_base(resp, expected):
+    name = talisker.requests.get_metric_name(resp)
     assert name == expected
-    assert duration == 1000.0
 
 
-def test_get_timing_hostname(monkeypatch):
+def test_get_metric_name_hostname(monkeypatch):
     monkeypatch.setitem(talisker.requests.HOSTS, '1.2.3.4', 'myhost.com')
     resp = response(host='http://1.2.3.4')
-    name, duration = talisker.requests.get_timing(resp)
+    name = talisker.requests.get_metric_name(resp)
     assert name == 'requests.myhost-com.GET.200'
-    assert duration == 1000.0
 
 
-def test_get_timing_path_len():
+def test_get_metric_name_path_len():
     resp = response(url='/foo/bar')
-    name, duration = talisker.requests.get_timing(resp, 2)
+    name = talisker.requests.get_metric_name(resp, 2)
     assert name == 'requests.example-com.foo.bar.GET.200'
-    assert duration == 1000.0
 
 
 def test_metric_hook(statsd_metrics):
     r = response()
-    talisker.requests.metrics_response_hook(r)
+
+    with raven.context.Context() as ctx:
+        talisker.requests.metrics_response_hook(r)
+
     assert statsd_metrics[0] == 'requests.example-com.GET.200:1000.000000|ms'
+    breadcrumbs = ctx.breadcrumbs.get_buffer()
+    assert breadcrumbs[1]['type'] == 'http'
+    assert breadcrumbs[1]['category'] == 'requests'
+    assert breadcrumbs[1]['data']['url'] == 'http://example.com/'
+    assert breadcrumbs[1]['data']['method'] == 'GET'
+    assert breadcrumbs[1]['data']['status_code'] == 200
+    assert breadcrumbs[1]['data']['duration'] == 1000.0
 
 
 @responses.activate
-def test_configured_session(statsd_metrics):
+def test_configured_session(statsd_metrics, ):
     session = requests.Session()
     talisker.requests.configure(session)
 
     responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
 
     with talisker.request_id.context('XXX'):
-        session.get('http://localhost/foo/bar')
+        with raven.context.Context() as ctx:
+            session.get('http://localhost/foo/bar')
 
     assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
     assert statsd_metrics[0].startswith('requests.localhost.GET.200:')
+    breadcrumbs = ctx.breadcrumbs.get_buffer()
+    assert breadcrumbs[1]['type'] == 'http'
+    assert breadcrumbs[1]['category'] == 'requests'
+    assert breadcrumbs[1]['data']['url'] == 'http://localhost/foo/bar'
+    assert breadcrumbs[1]['data']['method'] == 'GET'
+    assert breadcrumbs[1]['data']['status_code'] == 200
+    assert 'duration' in breadcrumbs[1]['data']
+
+
+def test_configured_session_connection_error(statsd_metrics):
+    session = requests.Session()
+    talisker.requests.configure(session)
+
+    with raven.context.Context() as ctx:
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.get('http://nowhere/')
+
+    breadcrumbs = ctx.breadcrumbs.get_buffer()
+    assert breadcrumbs[1]['type'] == 'http'
+    assert breadcrumbs[1]['category'] == 'requests'
+    assert breadcrumbs[1]['data']['url'] == 'http://nowhere/'
+    assert breadcrumbs[1]['data']['method'] == 'GET'
+    assert 'ConnectionError' in breadcrumbs[1]['data']['exception']
 
 
 @responses.activate


### PR DESCRIPTION
add breadcrumbs and logs to requests support, and allow disabling metrics for http requests.