### PR TITLE
Overwrite request_id and VCS headers, for when we are proxying

### DIFF
--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -21,6 +21,8 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
+from werkzeug.datastructures import Headers
+
 import talisker.request_id
 import talisker.context
 import talisker.endpoints
@@ -46,10 +48,12 @@ def set_environ(app, **kwargs):
 
 
 def set_headers(app, add_headers):
+    """Adds headers to response, overwriting any existing values."""
     def middleware(environ, start_response):
-        def custom_start_response(status, headers, exc_info=None):
+        def custom_start_response(status, response_headers, exc_info=None):
+            headers = Headers(response_headers)
             for header, value in add_headers.items():
-                headers.append((header, value))
+                headers.set(header, value)
             return start_response(status, headers, exc_info)
         return app(environ, custom_start_response)
     return middleware

--- a/tests/flask_app.py
+++ b/tests/flask_app.py
@@ -1,6 +1,7 @@
 from flask import Flask
 import sqlalchemy
 from sqlalchemy import Table, Column, Integer, String, MetaData, select
+from werkzeug.wrappers import Response
 
 
 import talisker.flask
@@ -29,9 +30,6 @@ conn.execute(select([users]))
 app = Flask(__name__)
 talisker.flask.register(app)
 
-talisker.requests.get_session().post(
-    'http://httpbin.org/post', json={'foo': 'bar'})
-
 
 @app.route('/')
 def index():
@@ -46,3 +44,9 @@ def error():
     talisker.requests.get_session().post(
         'http://httpbin.org/post', json={'foo': 'bar'})
     raise Exception('test')
+
+
+@app.route('/nested')
+def nested():
+    resp = talisker.requests.get_session().get('http://localhost:8001')
+    return Response(resp.content, status=200, headers=resp.headers.items())

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -49,7 +49,7 @@ def test_middleware_with_id(environ, id):
     environ['HTTP_X_REQUEST_ID'] = id
     body, status, headers = run_wsgi(middleware, environ)
     assert list(set(body)) == [id]
-    assert ('X-Request-Id', id) in headers
+    assert headers['X-Request-Id'] == id
 
 
 def test_middleware_without_id(environ, id, monkeypatch):
@@ -57,7 +57,7 @@ def test_middleware_without_id(environ, id, monkeypatch):
     middleware = request_id.RequestIdMiddleware(app)
     body, status, headers = run_wsgi(middleware, environ)
     assert list(set(body)) == [id]
-    assert ('X-Request-Id', id) in headers
+    assert headers['X-Request-Id'] == id
 
 
 def test_middleware_alt_header(environ, id):
@@ -65,7 +65,18 @@ def test_middleware_alt_header(environ, id):
     environ['HTTP_X_ALTERNATE'] = id
     body, status, headers = run_wsgi(middleware, environ)
     assert list(set(body)) == [id]
-    assert ('X-Alternate', id) in headers
+    assert headers['X-Alternate'] == id
+
+
+def test_middleware_overwrites_header(environ, id, monkeypatch):
+    def proxy(environ, start_response):
+        start_response(200, [('X-Request-Id', 'other-id')])
+        return 'ok'
+
+    monkeypatch.setattr(request_id, 'generate', lambda: id)
+    middleware = request_id.RequestIdMiddleware(proxy)
+    body, status, headers = run_wsgi(middleware, environ)
+    assert headers['X-Request-Id'] == id
 
 
 def test_decorator(id):

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -40,7 +40,16 @@ def test_set_environ(environ):
 def test_set_headers(environ):
     stack = wsgi.set_headers(app, {'extra': 'header'})
     env, status, headers = run_wsgi(stack, environ)
-    assert ('extra', 'header') in headers
+    assert headers['extra'] == 'header'
+
+
+def test_set_headers_overwrites(environ):
+    def proxy(environ, start_response):
+        start_response(200, [('extra', 'foo')])
+        return 'ok'
+    stack = wsgi.set_headers(app, {'extra': 'header'})
+    env, status, headers = run_wsgi(stack, environ)
+    assert headers['extra'] == 'header'
 
 
 def test_wrapping():


### PR DESCRIPTION
Avoids duplicating headers