### PR TITLE
Refactor requests logging/breadcrumbs/metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.pyc
 .cache
 .tox
-*.swp
+*.sw?
 *.egg-info
 .eggs
 *.egg

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -29,7 +29,7 @@ import sys
 import time
 
 from talisker.context import ContextStack
-from talisker.util import module_dict, module_cache
+from talisker.util import module_dict, module_cache, get_errno_fields
 
 
 __all__ = [
@@ -341,6 +341,8 @@ class StructuredFormatter(logging.Formatter):
 
         # add our structured tags *before* exception info is added
         structured = getattr(record, '_structured', {})
+        if record.exc_info and 'errno' not in structured:
+            structured.update(get_errno_fields(record.exc_info[1]))
         if structured:
             s += " " + self.logfmt(structured)
         # add talisker trailers

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -26,14 +26,15 @@ import functools
 import logging
 import threading
 
+from future.moves.urllib.parse import parse_qsl
 from future.utils import native
 import raven.breadcrumbs
 import requests
 import werkzeug.local
 
-from . import statsd
-from .util import parse_url
-from . import request_id
+from talisker import request_id
+from talisker import statsd
+from talisker.util import get_errno_fields, parse_url
 
 __all__ = [
     'configure',
@@ -79,56 +80,79 @@ def configure(session):
     # whatever, but still use talisker's enhancements.
     # If requests ever regains request hooks, then maybe this can go away
     # If anyone has a better solution, *please* tell me!
-    if not hasattr(session.send, '_inject_request_id'):
-        session.send = inject_request_id(session.send)
-    if not hasattr(session.request, '_metric_control'):
-        session.request = enable_metric_control(session.request)
+    if not hasattr(session.send, '_send_wrapper'):
+        session.send = send_wrapper(session.send)
+    if not hasattr(session.request, '_request_wrapper'):
+        session.request = request_wrapper(session.request)
 
 
-def inject_request_id(func):
+def send_wrapper(func):
+    """Sets header and records exception details."""
     @functools.wraps(func)
     def send(request, **kwargs):
-        id = request_id.get()
-        if id and HEADER not in request.headers:
-            request.headers[HEADER] = id
+        rid = request_id.get()
+        if rid and HEADER not in request.headers:
+            request.headers[HEADER] = rid
         try:
             return func(request, **kwargs)
         except Exception as e:
-            metadata = collect_metadata(request, None)
-            metadata['exception'] = repr(e)
-            logger.exception('http request failure', extra=metadata)
-            raven.breadcrumbs.record(
-                type='http',
-                category='requests',
-                data=metadata,
-            )
+            record_request(request, None, e)
             raise
 
-    send._inject_request_id = True
+    send._send_wrapper = True
     return send
 
 
-def enable_metric_control(func):
+def request_wrapper(func):
+    """Adds support for metric_name kwarg to session."""
     @functools.wraps(func)
     def request(method, url, **kwargs):
         try:
-            _local.metric_path_len = kwargs.pop('metric_path_len', 0)
-            _local.emit_metric = kwargs.pop('emit_metric', True)
+            _local.user_metric_name = kwargs.pop('metric_name', None)
             return func(method, url, **kwargs)
         finally:
-            del _local.metric_path_len
-            del _local.emit_metric
-    request._metric_control = True
+            del _local.user_metric_name
+    request._request_wrapper = True
     return request
 
 
 def collect_metadata(request, response):
     metadata = collections.OrderedDict()
-    metadata['url'] = request.url
+
+    parsed = parse_url(request.url)
+
+    if parsed.hostname in HOSTS:
+        hostname = HOSTS[parsed.hostname]
+        ip = parsed.hostname
+        netloc = hostname
+        if parsed.port:
+            netloc += ':{}'.format(parsed.port)
+    else:
+        hostname = parsed.hostname
+        ip = None
+        netloc = parsed.netloc
+
+    # do not include querystring in url, as may have senstive
+    metadata['url'] = '{}://{}{}'.format(parsed.scheme, netloc, parsed.path)
+    if parsed.query:
+        metadata['url'] += '?'
+        redacted = ('{}=<len {}>'.format(k, len(v))
+                    for k, v in parse_qsl(parsed.query))
+        metadata['qs'] = '?' + '&'.join(redacted)
+        metadata['qs_size'] = len(parsed.query)
+
     metadata['method'] = request.method
+    metadata['host'] = hostname
+    if ip is not None:
+        metadata['ip'] = ip
 
     if response is not None:
         metadata['status_code'] = response.status_code
+       
+        if 'X-View-Name' in response.headers:
+            metadata['view'] = response.headers['X-View-Name']
+        if 'Server' in response.headers:
+            metadata['server'] = response.headers['Server']
         duration = response.elapsed.total_seconds() * 1000
         metadata['duration'] = duration
 
@@ -136,11 +160,12 @@ def collect_metadata(request, response):
     if request_type is not None:
         metadata['request_type'] = request_type
 
-    try:
-        metadata['request_size'] = int(
-            request.headers.get('content-length', 0))
-    except ValueError:
-        pass
+    if metadata['method'] in ('POST', 'PUT', 'PATCH'):
+        try:
+            metadata['request_size'] = int(
+                request.headers.get('content-length', 0))
+        except ValueError:
+            pass
 
     if response is not None:
         response_type = response.headers.get('content-type', None)
@@ -158,41 +183,59 @@ def collect_metadata(request, response):
 def metrics_response_hook(response, **kwargs):
     """Response hook that records statsd metrics and breadcrumbs."""
     try:
-        metadata = collect_metadata(response.request, response)
-        logger.info('http request', extra=metadata)
-
-        # massage breadcrumb data to meet sentry expectations for http request
-        raven.breadcrumbs.record(
-            type='http', category='requests', data=metadata)
-
-        if getattr(_local, 'emit_metric', True):
-            path_len = getattr(_local, 'metric_path_len', 0)
-            metric_name = get_metric_name(response, path_len)
-            statsd.get_client().timing(metric_name, metadata['duration'])
+        record_request(response.request, response)
     except Exception:
         logging.exception('response hook error')
 
 
-def get_metric_name(response, path_len=0):
-    parsed = parse_url(response.request.url)
-    if parsed.hostname in HOSTS:
-        hostname = HOSTS[parsed.hostname]
-    else:
-        hostname = parsed.hostname
-    if path_len > 0:
-        path_components = parsed.path.lstrip('/').split('/')
-        dotted_path = '.'.join(path_components[:path_len])
-        url_components = '{}.'.format(dotted_path)
-    else:
-        url_components = ''
+def record_request(request, response=None, exc=None):
+    metadata = collect_metadata(request, response)
 
-    prefix = 'requests.{}.{}{}.{}'.format(
-        hostname.replace('.', '-'),
-        url_components,
-        response.request.method.upper(),
-        str(response.status_code),
+    if exc:
+        metadata.update(get_errno_fields(exc))
+
+    raven.breadcrumbs.record(
+        type='http',
+        category='requests',
+        data=metadata,
     )
-    return prefix
+
+    if response is None:
+        # likely connection errors
+        logger.exception('http request failure', extra=metadata)
+        statsd.get_client().incr(
+            'requests.{}.error.{}'.format(
+                metadata['host'].replace('.', '-'),
+                metadata.get('errno', 'unknown'),
+            )
+        )
+    else:
+        logger.info('http request', extra=metadata)
+
+        user_name = getattr(_local, 'user_metric_name', None)
+        if user_name is None:
+            metric_name = get_metric_name(metadata)
+        else:
+            clean_meta = {k: str(v).replace('.', '-')
+                          for k, v in metadata.items()}
+            metric_name = user_name.format(**clean_meta)
+
+        statsd.get_client().timing(
+            'requests.' + metric_name,
+            metadata['duration'],
+        )
+
+
+def get_metric_name(metadata):
+    view = ''
+    if 'view' in metadata:
+        view = metadata['view'] + '.'
+    return '{}.{}{}.{}'.format(
+        metadata['host'].replace('.', '-'),
+        view,
+        metadata['method'].upper(),
+        str(metadata['status_code']),
+    )
 
 
 def enable_requests_logging():  # pragma: nocover

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -148,7 +148,7 @@ def collect_metadata(request, response):
 
     if response is not None:
         metadata['status_code'] = response.status_code
-       
+
         if 'X-View-Name' in response.headers:
             metadata['view'] = response.headers['X-View-Name']
         if 'Server' in response.headers:

--- a/talisker/util.py
+++ b/talisker/util.py
@@ -155,9 +155,9 @@ def get_errno_fields(exc):
     root = get_root_exception(exc)
     fields = {}
     # these fields are standard fields in the OSError heirarchy
-    if hasattr(root, 'errno'):
+    if getattr(root, 'errno', None):
         fields['errno'] = ERROR_CODES.get(root.errno, str(root.errno))
-    if hasattr(root, 'strerror'):
+    if getattr(root, 'strerror', None):
         fields['strerror'] = root.strerror
     if getattr(root, 'filename', None) is not None:
         fields['filename'] = root.filename

--- a/talisker/util.py
+++ b/talisker/util.py
@@ -21,11 +21,30 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
+import errno
 import functools
 import logging
 import pkg_resources
+import sys
 
 from future.moves.urllib.parse import urlparse
+
+
+# look up table for errno's
+# FIXME: maybe add more codes?
+ERROR_CODES = errno.errorcode.copy()
+ERROR_CODES[-1] = 'EAI_BADFLAGS'
+ERROR_CODES[-2] = 'EAI_NONAME'
+ERROR_CODES[-3] = 'EAI_AGAIN'
+ERROR_CODES[-4] = 'EAI_FAIL'
+ERROR_CODES[-5] = 'EAI_NODATA'
+ERROR_CODES[-6] = 'EAI_FAMILY'
+ERROR_CODES[-7] = 'EAI_SOCKTYPE'
+ERROR_CODES[-8] = 'EAI_SERVICE'
+ERROR_CODES[-9] = 'EAI_ADDRFAMILY'
+ERROR_CODES[-10] = 'EAI_MEMORY'
+ERROR_CODES[-11] = 'EAI_SYSTEM'
+ERROR_CODES[-12] = 'EAI_OVERFLOW'
 
 
 def parse_url(url, proto='http'):
@@ -114,3 +133,34 @@ def clear_globals():
     _global_cache.clear()
     for d in _global_dicts:
         d.clear()
+
+
+if sys.version_info[0:2] >= (3, 3):
+    def get_root_exception(exc):
+        root = exc
+        while root.__cause__ is not None or root.__context__ is not None:
+            if root.__cause__ is not None:
+                root = root.__cause__
+            elif root.__context__ is not None:
+                root = root.__context__
+        return root
+
+else:
+    def get_root_exception(exc):
+        return exc
+
+
+def get_errno_fields(exc):
+    """Best effort attempt to get any POSIX errno codes from exception."""
+    root = get_root_exception(exc)
+    fields = {}
+    # these fields are standard fields in the OSError heirarchy
+    if hasattr(root, 'errno'):
+        fields['errno'] = ERROR_CODES.get(root.errno, str(root.errno))
+    if hasattr(root, 'strerror'):
+        fields['strerror'] = root.strerror
+    if getattr(root, 'filename', None) is not None:
+        fields['filename'] = root.filename
+    if getattr(root, 'filename2', None) is not None:
+        fields['filename2'] = root.filename2
+    return fields

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -28,7 +28,6 @@ import logging
 from collections import OrderedDict
 from gunicorn.config import Config
 
-import pytest
 from talisker import gunicorn
 from talisker import logs
 

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -70,6 +70,7 @@ class TestResponse:
 
 def access_extra_args(environ, url='/'):
     response = TestResponse()
+    response.headers.append(('X-View-Name', 'view'))
     delta = datetime.timedelta(seconds=1)
     parts = url.split('?')
     path = parts[0]
@@ -85,12 +86,13 @@ def access_extra_args(environ, url='/'):
     expected['path'] = path
     expected['qs'] = qs
     expected['status'] = 200
+    expected['view'] = 'view'
+    expected['duration'] = 1000.0
     expected['ip'] = '127.0.0.1'
     expected['proto'] = 'HTTP/1.0'
     expected['length'] = 1000
     expected['referrer'] = 'referrer'
     expected['ua'] = 'ua'
-    expected['duration'] = 1000.0
     return response, environ, delta, expected
 
 
@@ -133,9 +135,7 @@ def test_gunicorn_logger_access(environ, log, statsd_metrics):
     assert log[0]._structured == expected
     assert log[0].msg == 'GET /'
 
-    assert 'gunicorn.request.duration:' in statsd_metrics[0]
-    assert 'gunicorn.requests:1|c' in statsd_metrics[1]
-    assert 'gunicorn.request.status.200:1|c' in statsd_metrics[2]
+    assert 'gunicorn.views.view.GET.200:' in statsd_metrics[0]
 
 
 def test_gunicorn_logger_access_qs(environ, log):
@@ -164,17 +164,6 @@ def test_gunicorn_logger_access_with_request_id(environ, log):
     log[:] = []
     logger.access(response, None, environ, delta)
     assert log[0]._structured == expected
-
-
-@pytest.mark.parametrize('level', 'critical error warning exception'.split())
-def test_gunicorn_logger_logging(level, statsd_metrics, log):
-    cfg = Config()
-    logger = gunicorn.GunicornLogger(cfg)
-    getattr(logger, level)(level)
-    expected = 'ERROR' if level == 'exception' else level.upper()
-    assert log[0].levelname == expected
-    assert log[0].getMessage() == level
-    assert 'gunicorn.log.{}:1|c'.format(level) in statsd_metrics[0]
 
 
 def test_gunicorn_application_init(monkeypatch):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -15,64 +15,159 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 from datetime import timedelta
+from io import StringIO
 
 import pytest
 import raven.context
 import requests
 import responses
+from werkzeug.local import release_local
 
 import talisker.requests
 import talisker.statsd
 
 
-def response(
+def request(
         method='GET',
         host='http://example.com',
         url='/',
+        **kwargs
+    ):
+    req = requests.Request(method, url=host+url, **kwargs)
+    return req.prepare()
+
+def response(
+        req=None, 
         code=200,
+        view=None,
+        body=None,
+        content_type='text/plain',
+        headers={},
         elapsed=1.0):
-    req = requests.Request(method, host + url)
+    if req is None:
+       req = request()
     resp = requests.Response()
-    resp.request = req.prepare()
+    resp.request = req
     resp.status_code = code
     resp.elapsed = timedelta(seconds=elapsed)
+    resp.headers['Server'] = 'test/1.0'
+    if body is not None:
+        resp.raw = StringIO(body) 
+        resp.headers['Content-Length'] = len(body)
+        resp.headers['Content-Type'] = content_type
+    if view is not None:
+        resp.headers['X-View-Name'] = view
+    resp.headers.update(headers)
     return resp
 
 
 @pytest.mark.parametrize('resp, expected', [
-    (response(), 'requests.example-com.GET.200'),
-    (response(method='POST'), 'requests.example-com.POST.200'),
-    (response(code=500), 'requests.example-com.GET.500'),
+    (response(), 'example-com.GET.200'),
+    (response(request(method='POST')), 'example-com.POST.200'),
+    (response(code=500), 'example-com.GET.500'),
+    (response(view='view.name'), 'example-com.view.name.GET.200'),
 ])
 def test_get_metric_name_base(resp, expected):
-    name = talisker.requests.get_metric_name(resp)
+    metadata = talisker.requests.collect_metadata(resp.request, resp)
+    name = talisker.requests.get_metric_name(metadata)
     assert name == expected
 
 
 def test_get_metric_name_hostname(monkeypatch):
     monkeypatch.setitem(talisker.requests.HOSTS, '1.2.3.4', 'myhost.com')
-    resp = response(host='http://1.2.3.4')
-    name = talisker.requests.get_metric_name(resp)
-    assert name == 'requests.myhost-com.GET.200'
+    resp = response(request(host='http://1.2.3.4'))
+    metadata = talisker.requests.collect_metadata(resp.request, resp)
+    name = talisker.requests.get_metric_name(metadata)
+    assert name == 'myhost-com.GET.200'
 
 
-def test_get_metric_name_path_len():
-    resp = response(url='/foo/bar')
-    name = talisker.requests.get_metric_name(resp, 2)
-    assert name == 'requests.example-com.foo.bar.GET.200'
+def test_collect_metadata():
+    req = request(url='/foo/bar')
+    metadata = talisker.requests.collect_metadata(req, None)
+    assert metadata == {
+        'url': 'http://example.com/foo/bar',
+        'method': 'GET',
+        'host': 'example.com',
+    }
+
+
+def test_collect_metadata_request_body():
+    req = request(method='POST', url='/foo/bar', json='"some data"')
+    metadata = talisker.requests.collect_metadata(req, None)
+    assert metadata == {
+        'url': 'http://example.com/foo/bar',
+        'method': 'POST',
+        'host': 'example.com',
+        'request_type': 'application/json',
+        'request_size': 15,
+    }
+
+
+def test_collect_metadata_querystring():
+    req = request(url='/foo/bar?baz=1&qux=data')
+    metadata = talisker.requests.collect_metadata(req, None)
+    assert metadata == {
+        'url': 'http://example.com/foo/bar?',
+        'qs': '?baz=<len 1>&qux=<len 4>',
+        'qs_size': 14,
+        'method': 'GET',
+        'host': 'example.com',
+    }
+
+
+def test_collect_metadata_with_response():
+    req = request(url='/foo/bar')
+    resp = response(req, view='views.name', body='some content')
+    metadata = talisker.requests.collect_metadata(req, resp)
+    assert metadata == {
+        'url': 'http://example.com/foo/bar',
+        'method': 'GET',
+        'host': 'example.com',
+        'status_code': 200,
+        'view': 'views.name',
+        'server': 'test/1.0',
+        'duration': 1000,
+        'response_type': 'text/plain',
+        'response_size': 12,
+    }
 
 
 def test_metric_hook(statsd_metrics):
-    r = response()
+    r = response(view='view.name')
 
     with raven.context.Context() as ctx:
         talisker.requests.metrics_response_hook(r)
 
-    assert statsd_metrics[0] == 'requests.example-com.GET.200:1000.000000|ms'
+    assert statsd_metrics[0] == (
+        'requests.example-com.view.name.GET.200:1000.000000|ms'
+    )
     breadcrumbs = ctx.breadcrumbs.get_buffer()
     assert breadcrumbs[0]['type'] == 'http'
     assert breadcrumbs[0]['category'] == 'requests'
     assert breadcrumbs[0]['data']['url'] == 'http://example.com/'
+    assert breadcrumbs[0]['data']['host'] == 'example.com'
+    assert breadcrumbs[0]['data']['method'] == 'GET'
+    assert breadcrumbs[0]['data']['view'] == 'view.name'
+    assert breadcrumbs[0]['data']['status_code'] == 200
+    assert breadcrumbs[0]['data']['duration'] == 1000.0
+
+
+def test_metric_hook_user_name(statsd_metrics):
+    r = response(view='view.name')
+
+    with raven.context.Context() as ctx:
+        name = 'foo.{host}.{status_code}'
+        talisker.requests._local.user_metric_name = name
+        talisker.requests.metrics_response_hook(r)
+        release_local(talisker.requests._local)
+
+    assert statsd_metrics[0] == 'requests.foo.example-com.200:1000.000000|ms'
+    breadcrumbs = ctx.breadcrumbs.get_buffer()
+    assert breadcrumbs[0]['type'] == 'http'
+    assert breadcrumbs[0]['category'] == 'requests'
+    assert breadcrumbs[0]['data']['url'] == 'http://example.com/'
+    assert breadcrumbs[0]['data']['host'] == 'example.com'
+    assert breadcrumbs[0]['data']['view'] == 'view.name'
     assert breadcrumbs[0]['data']['method'] == 'GET'
     assert breadcrumbs[0]['data']['status_code'] == 200
     assert breadcrumbs[0]['data']['duration'] == 1000.0
@@ -83,19 +178,28 @@ def test_configured_session(statsd_metrics, ):
     session = requests.Session()
     talisker.requests.configure(session)
 
-    responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
+    responses.add(
+        responses.GET,
+        'http://localhost/foo/bar',
+        body='OK',
+        headers={'X-View-Name': 'view.name'},
+    )
 
     with talisker.request_id.context('XXX'):
         with raven.context.Context() as ctx:
             session.get('http://localhost/foo/bar')
 
     assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
-    assert statsd_metrics[0].startswith('requests.localhost.GET.200:')
+    assert statsd_metrics[0].startswith(
+        'requests.localhost.view.name.GET.200:',
+    )
     breadcrumbs = ctx.breadcrumbs.get_buffer()
 
     assert breadcrumbs[0]['type'] == 'http'
     assert breadcrumbs[0]['category'] == 'requests'
     assert breadcrumbs[0]['data']['url'] == 'http://localhost/foo/bar'
+    assert breadcrumbs[0]['data']['host'] == 'localhost'
+    assert breadcrumbs[0]['data']['view'] == 'view.name'
     assert breadcrumbs[0]['data']['method'] == 'GET'
     assert breadcrumbs[0]['data']['status_code'] == 200
     assert 'duration' in breadcrumbs[0]['data']
@@ -106,48 +210,32 @@ def test_configured_session_connection_error(statsd_metrics):
     talisker.requests.configure(session)
 
     with raven.context.Context() as ctx:
-        with pytest.raises(requests.exceptions.ConnectionError):
-            session.get('http://nowhere/')
+        with pytest.raises(requests.exceptions.ConnectionError) as e:
+            session.get('http://nowhere.tlddoesnotexist/foo', )
+
 
     breadcrumbs = ctx.breadcrumbs.get_buffer()
     assert breadcrumbs[-1]['type'] == 'http'
     assert breadcrumbs[-1]['category'] == 'requests'
-    assert breadcrumbs[-1]['data']['url'] == 'http://nowhere/'
+    assert breadcrumbs[-1]['data']['url'] == 'http://nowhere.tlddoesnotexist/foo'
+    assert breadcrumbs[-1]['data']['host'] == 'nowhere.tlddoesnotexist'
     assert breadcrumbs[-1]['data']['method'] == 'GET'
-    assert 'ConnectionError' in breadcrumbs[-1]['data']['exception']
+    # error code depends if we are running tests with network or not
+    assert breadcrumbs[-1]['data']['errno'] in ('EAI_NONAME', 'EAI_AGAIN')
 
 
 @responses.activate
-def test_configured_session_disable_metrics(statsd_metrics):
+def test_configured_session_with_user_name(statsd_metrics):
     session = requests.Session()
     talisker.requests.configure(session)
 
     responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
 
     with talisker.request_id.context('XXX'):
-        session.get('http://localhost/foo/bar', emit_metric=False)
+        session.get(
+            'http://localhost/foo/bar',
+            metric_name='foo.{host}.name.{status_code}',
+        )
 
     assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
-    assert len(statsd_metrics) == 0
-
-
-@responses.activate
-def test_configured_session_with_url_metrics(statsd_metrics):
-    session = requests.Session()
-    talisker.requests.configure(session)
-
-    responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
-
-    with talisker.request_id.context('XXX'):
-        session.get('http://localhost/foo/bar', metric_path_len=1)
-        session.get('http://localhost/foo/bar', metric_path_len=2)
-        session.get('http://localhost/foo/bar')
-
-    assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
-    assert statsd_metrics[0].startswith('requests.localhost.foo.GET.200:')
-
-    assert responses.calls[1].request.headers['X-Request-Id'] == 'XXX'
-    assert statsd_metrics[1].startswith('requests.localhost.foo.bar.GET.200:')
-
-    assert responses.calls[2].request.headers['X-Request-Id'] == 'XXX'
-    assert statsd_metrics[2].startswith('requests.localhost.GET.200:')
+    assert statsd_metrics[0].startswith('requests.foo.localhost.name.200:')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,123 @@
+
+# Copyright (C) 2016- Canonical Ltd
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+from builtins import *  # noqa
+
+import talisker.util
+
+
+def test_get_root_exception_implicit():
+    exc = None
+
+    try:
+        try:
+            try:
+                raise Exception('root')
+            except Exception:
+                raise Exception('one')
+        except Exception:
+            raise Exception('two')
+    except Exception as e:
+        exc = e
+
+    root = talisker.util.get_root_exception(exc)
+    assert root.args == ('root',)
+
+
+def test_get_root_exception_explicit():
+    exc = None
+
+    try:
+        try:
+            try:
+                raise Exception('root')
+            except Exception as a:
+                raise Exception('one') from a
+        except Exception as b:
+            raise Exception('two') from b
+    except Exception as c:
+        exc = c
+
+    root = talisker.util.get_root_exception(exc)
+    assert root.args == ('root',)
+
+
+def test_get_root_exception_mixed():
+    exc = None
+
+    try:
+        try:
+            try:
+                raise Exception('root')
+            except Exception as a:
+                raise Exception('one') from a
+        except Exception:
+            raise Exception('two')
+    except Exception as e:
+        exc = e
+
+    root = talisker.util.get_root_exception(exc)
+    assert root.args == ('root',)
+
+
+def test_get_errno_fields_permissions():
+    exc = None
+    try:
+        open('/blah', 'w')
+    except Exception as e:
+        exc = e
+
+    assert talisker.util.get_errno_fields(exc) == {
+        'errno': 'EACCES',
+        'strerror': 'Permission denied',
+        'filename': '/blah',
+    }
+
+
+def test_get_errno_fields_connection():
+    exc = None
+    try:
+        import socket
+        s = socket.socket()
+        s.connect(('localhost', 54321))
+    except Exception as e:
+        exc = e
+
+    assert talisker.util.get_errno_fields(exc) == {
+        'errno': 'ECONNREFUSED',
+        'strerror': 'Connection refused',
+    }
+
+
+def test_get_errno_fields_dns():
+    exc = None
+    try:
+        import socket
+        s = socket.socket()
+        s.connect(('some-host-name-that-will-not-resolve.com', 54321))
+    except Exception as e:
+        exc = e
+
+    assert talisker.util.get_errno_fields(exc) == {
+        'errno': 'EAI_NONAME',
+        'strerror': 'Name or service not known',
+    }

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -22,9 +22,15 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
+import sys
+import textwrap
+
+import pytest
+
 import talisker.util
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3, 3), reason='>=py3.3 only')
 def test_get_root_exception_implicit():
     exc = None
 
@@ -43,9 +49,11 @@ def test_get_root_exception_implicit():
     assert root.args == ('root',)
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3, 3), reason='>=py3.3 only')
 def test_get_root_exception_explicit():
+    # have to exec this so we don't break pytest collection under py2
+    code = textwrap.dedent("""
     exc = None
-
     try:
         try:
             try:
@@ -56,14 +64,20 @@ def test_get_root_exception_explicit():
             raise Exception('two') from b
     except Exception as c:
         exc = c
-
+    """)
+    locals = {}
+    exec(code, None, locals)
+    exc = locals['exc']
     root = talisker.util.get_root_exception(exc)
     assert root.args == ('root',)
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3, 3), reason='>=py3.3 only')
 def test_get_root_exception_mixed():
-    exc = None
 
+    # have to exec this so we don't break pytest collection under py2
+    code = textwrap.dedent("""
+    exc = None
     try:
         try:
             try:
@@ -74,7 +88,10 @@ def test_get_root_exception_mixed():
             raise Exception('two')
     except Exception as e:
         exc = e
-
+    """)
+    locals = {}
+    exec(code, None, locals)
+    exc = locals['exc']
     root = talisker.util.get_root_exception(exc)
     assert root.args == ('root',)
 


### PR DESCRIPTION
 - actually log http requests
 - richer metadata
- use new view-name header in requests and gunicorn metrics
 - record non-response errors (e.g. connection failures)
 - improve general exception logging with more context when available