### PR TITLE
Add logging for X-Forwarded-For header

### DIFF
--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -84,6 +84,8 @@ class GunicornLogger(Logger):
         extra['status'] = status
         if 'x-view-name' in headers:
             extra['view'] = headers['x-view-name']
+        if 'x-forwarded-for' in headers:
+            extra['forwarded'] = headers['x-forwarded-for']
         extra['duration'] = (
             request_time.seconds * 1000 +
             float(request_time.microseconds) / 1000

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -84,8 +84,6 @@ class GunicornLogger(Logger):
         extra['status'] = status
         if 'x-view-name' in headers:
             extra['view'] = headers['x-view-name']
-        if 'x-forwarded-for' in headers:
-            extra['forwarded'] = headers['x-forwarded-for']
         extra['duration'] = (
             request_time.seconds * 1000 +
             float(request_time.microseconds) / 1000
@@ -96,6 +94,8 @@ class GunicornLogger(Logger):
         referrer = environ.get('HTTP_REFERER', None)
         if referrer is not None:
             extra['referrer'] = environ.get('HTTP_REFERER', None)
+        if 'HTTP_X_FORWARDED_FOR' in environ:
+            extra['forwarded'] = environ['HTTP_X_FORWARDED_FOR']
         extra['ua'] = environ.get('HTTP_USER_AGENT', None)
 
         request_id = headers.get('x-request-id')


### PR DESCRIPTION
If an X-Forwarded-For header is present, add it to the gunicorn access log output under the 'forwarded' attribute.

Do not otherwise mangle the header / REMOTE_IP to prevent any problems with handling implemented elsewhere in client applications.