### PR TITLE
Refactor requests metrics/logging, again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.pyc
 .cache
 .tox
-*.swp
+*.sw?
 *.egg-info
 .eggs
 *.egg

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -134,7 +134,7 @@ def collect_metadata(request, response):
         ip = None
         netloc = parsed.netloc
 
-    # do not include querystring in url, as may have senstive
+    # do not include querystring in url, as may have senstive info
     metadata['url'] = '{}://{}{}'.format(parsed.scheme, netloc, parsed.path)
     if parsed.query:
         metadata['url'] += '?'

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -26,14 +26,15 @@ import functools
 import logging
 import threading
 
+from future.moves.urllib.parse import parse_qsl
 from future.utils import native
 import raven.breadcrumbs
 import requests
 import werkzeug.local
 
-from . import statsd
-from .util import parse_url
-from . import request_id
+from talisker import request_id
+from talisker import statsd
+from talisker.util import get_errno_fields, parse_url
 
 __all__ = [
     'configure',
@@ -79,56 +80,81 @@ def configure(session):
     # whatever, but still use talisker's enhancements.
     # If requests ever regains request hooks, then maybe this can go away
     # If anyone has a better solution, *please* tell me!
-    if not hasattr(session.send, '_inject_request_id'):
-        session.send = inject_request_id(session.send)
-    if not hasattr(session.request, '_metric_control'):
-        session.request = enable_metric_control(session.request)
+    if not hasattr(session.send, '_send_wrapper'):
+        session.send = send_wrapper(session.send)
+    if not hasattr(session.request, '_request_wrapper'):
+        session.request = request_wrapper(session.request)
 
 
-def inject_request_id(func):
+def send_wrapper(func):
+    """Sets header and records exception details."""
     @functools.wraps(func)
     def send(request, **kwargs):
-        id = request_id.get()
-        if id and HEADER not in request.headers:
-            request.headers[HEADER] = id
+        rid = request_id.get()
+        if rid and HEADER not in request.headers:
+            request.headers[HEADER] = rid
         try:
             return func(request, **kwargs)
         except Exception as e:
-            metadata = collect_metadata(request, None)
-            metadata['exception'] = repr(e)
-            logger.exception('http request failure', extra=metadata)
-            raven.breadcrumbs.record(
-                type='http',
-                category='requests',
-                data=metadata,
-            )
+            record_request(request, None, e)
             raise
 
-    send._inject_request_id = True
+    send._send_wrapper = True
     return send
 
 
-def enable_metric_control(func):
+def request_wrapper(func):
+    """Adds support for metric_name kwarg to session."""
     @functools.wraps(func)
     def request(method, url, **kwargs):
         try:
-            _local.metric_path_len = kwargs.pop('metric_path_len', 0)
-            _local.emit_metric = kwargs.pop('emit_metric', True)
+            _local.metric_api_name = kwargs.pop('metric_api_name', None)
+            _local.metric_host_name = kwargs.pop('metric_host_name', None)
             return func(method, url, **kwargs)
         finally:
-            del _local.metric_path_len
-            del _local.emit_metric
-    request._metric_control = True
+            del _local.metric_api_name
+            del _local.metric_host_name
+    request._request_wrapper = True
     return request
 
 
 def collect_metadata(request, response):
     metadata = collections.OrderedDict()
-    metadata['url'] = request.url
+
+    parsed = parse_url(request.url)
+
+    if parsed.hostname in HOSTS:
+        hostname = HOSTS[parsed.hostname]
+        ip = parsed.hostname
+        netloc = hostname
+        if parsed.port:
+            netloc += ':{}'.format(parsed.port)
+    else:
+        hostname = parsed.hostname
+        ip = None
+        netloc = parsed.netloc
+
+    # do not include querystring in url, as may have senstive
+    metadata['url'] = '{}://{}{}'.format(parsed.scheme, netloc, parsed.path)
+    if parsed.query:
+        metadata['url'] += '?'
+        redacted = ('{}=<len {}>'.format(k, len(v))
+                    for k, v in parse_qsl(parsed.query))
+        metadata['qs'] = '?' + '&'.join(redacted)
+        metadata['qs_size'] = len(parsed.query)
+
     metadata['method'] = request.method
+    metadata['host'] = hostname
+    if ip is not None:
+        metadata['ip'] = ip
 
     if response is not None:
         metadata['status_code'] = response.status_code
+
+        if 'X-View-Name' in response.headers:
+            metadata['view'] = response.headers['X-View-Name']
+        if 'Server' in response.headers:
+            metadata['server'] = response.headers['Server']
         duration = response.elapsed.total_seconds() * 1000
         metadata['duration'] = duration
 
@@ -136,11 +162,12 @@ def collect_metadata(request, response):
     if request_type is not None:
         metadata['request_type'] = request_type
 
-    try:
-        metadata['request_size'] = int(
-            request.headers.get('content-length', 0))
-    except ValueError:
-        pass
+    if metadata['method'] in ('POST', 'PUT', 'PATCH'):
+        try:
+            metadata['request_size'] = int(
+                request.headers.get('content-length', 0))
+        except ValueError:
+            pass
 
     if response is not None:
         response_type = response.headers.get('content-type', None)
@@ -158,41 +185,51 @@ def collect_metadata(request, response):
 def metrics_response_hook(response, **kwargs):
     """Response hook that records statsd metrics and breadcrumbs."""
     try:
-        metadata = collect_metadata(response.request, response)
-        logger.info('http request', extra=metadata)
-
-        # massage breadcrumb data to meet sentry expectations for http request
-        raven.breadcrumbs.record(
-            type='http', category='requests', data=metadata)
-
-        if getattr(_local, 'emit_metric', True):
-            path_len = getattr(_local, 'metric_path_len', 0)
-            metric_name = get_metric_name(response, path_len)
-            statsd.get_client().timing(metric_name, metadata['duration'])
+        record_request(response.request, response)
     except Exception:
         logging.exception('response hook error')
 
 
-def get_metric_name(response, path_len=0):
-    parsed = parse_url(response.request.url)
-    if parsed.hostname in HOSTS:
-        hostname = HOSTS[parsed.hostname]
-    else:
-        hostname = parsed.hostname
-    if path_len > 0:
-        path_components = parsed.path.lstrip('/').split('/')
-        dotted_path = '.'.join(path_components[:path_len])
-        url_components = '{}.'.format(dotted_path)
-    else:
-        url_components = ''
+def record_request(request, response=None, exc=None):
+    metadata = collect_metadata(request, response)
 
-    prefix = 'requests.{}.{}{}.{}'.format(
-        hostname.replace('.', '-'),
-        url_components,
-        response.request.method.upper(),
-        str(response.status_code),
+    if exc:
+        metadata.update(get_errno_fields(exc))
+
+    raven.breadcrumbs.record(
+        type='http',
+        category='requests',
+        data=metadata,
     )
-    return prefix
+
+    if response is None:
+        # likely connection errors
+        logger.exception('http request failure', extra=metadata)
+        statsd.get_client().incr(
+            'requests.{}.error.{}'.format(
+                metadata['host'].replace('.', '-'),
+                metadata.get('errno', 'unknown'),
+            )
+        )
+    else:
+        logger.info('http request', extra=metadata)
+
+        metric_api_name = getattr(_local, 'metric_api_name', None)
+        if metric_api_name is None:
+            metric_api_name = metadata.get('view', 'unknown-view')
+        metric_host_name = getattr(_local, 'metric_host_name', None)
+        if metric_host_name is None:
+            metric_host_name = metadata.get('host', 'unknown-host')
+
+        statsd.get_client().timing(
+            'requests.{}.{}.{}.{}'.format(
+                metric_host_name.replace('.', '-'),
+                metric_api_name,
+                metadata['method'],
+                metadata['status_code'],
+            ),
+            metadata['duration'],
+        )
 
 
 def enable_requests_logging():  # pragma: nocover

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -16,6 +16,7 @@
 
 from datetime import timedelta
 from io import StringIO
+import sys
 
 import pytest
 import raven.context
@@ -80,7 +81,7 @@ def test_collect_metadata_hostname(monkeypatch):
 
 
 def test_collect_metadata_request_body():
-    req = request(method='POST', url='/foo/bar', json='"some data"')
+    req = request(method='POST', url='/foo/bar', json=u'"some data"')
     metadata = talisker.requests.collect_metadata(req, None)
     assert metadata == {
         'url': 'http://example.com/foo/bar',
@@ -105,7 +106,7 @@ def test_collect_metadata_querystring():
 
 def test_collect_metadata_with_response():
     req = request(url='/foo/bar')
-    resp = response(req, view='views.name', body='some content')
+    resp = response(req, view='views.name', body=u'some content')
     metadata = talisker.requests.collect_metadata(req, resp)
     assert metadata == {
         'url': 'http://example.com/foo/bar',
@@ -210,7 +211,8 @@ def test_configured_session_connection_error(statsd_metrics):
     assert breadcrumbs[-1]['data']['host'] == 'nowhere.doesnotexist'
     assert breadcrumbs[-1]['data']['method'] == 'GET'
     # error code depends if we are running tests with network or not
-    assert breadcrumbs[-1]['data']['errno'] in ('EAI_NONAME', 'EAI_AGAIN')
+    if sys.version_info[:2] >= (3, 3):
+        assert breadcrumbs[-1]['data']['errno'] in ('EAI_NONAME', 'EAI_AGAIN')
 
 
 @responses.activate

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -15,64 +15,149 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 from datetime import timedelta
+from io import StringIO
 
 import pytest
 import raven.context
 import requests
 import responses
+from werkzeug.local import release_local
 
 import talisker.requests
 import talisker.statsd
 
 
+def request(method='GET', host='http://example.com', url='/', **kwargs):
+    req = requests.Request(method, url=host + url, **kwargs)
+    return req.prepare()
+
+
 def response(
-        method='GET',
-        host='http://example.com',
-        url='/',
+        req=None,
         code=200,
+        view=None,
+        body=None,
+        content_type='text/plain',
+        headers={},
         elapsed=1.0):
-    req = requests.Request(method, host + url)
+    if req is None:
+        req = request()
     resp = requests.Response()
-    resp.request = req.prepare()
+    resp.request = req
     resp.status_code = code
     resp.elapsed = timedelta(seconds=elapsed)
+    resp.headers['Server'] = 'test/1.0'
+    if body is not None:
+        resp.raw = StringIO(body)
+        resp.headers['Content-Length'] = len(body)
+        resp.headers['Content-Type'] = content_type
+    if view is not None:
+        resp.headers['X-View-Name'] = view
+    resp.headers.update(headers)
     return resp
 
 
-@pytest.mark.parametrize('resp, expected', [
-    (response(), 'requests.example-com.GET.200'),
-    (response(method='POST'), 'requests.example-com.POST.200'),
-    (response(code=500), 'requests.example-com.GET.500'),
-])
-def test_get_metric_name_base(resp, expected):
-    name = talisker.requests.get_metric_name(resp)
-    assert name == expected
+def test_collect_metadata():
+    req = request(url='/foo/bar')
+    metadata = talisker.requests.collect_metadata(req, None)
+    assert metadata == {
+        'url': 'http://example.com/foo/bar',
+        'method': 'GET',
+        'host': 'example.com',
+    }
 
 
-def test_get_metric_name_hostname(monkeypatch):
+def test_collect_metadata_hostname(monkeypatch):
     monkeypatch.setitem(talisker.requests.HOSTS, '1.2.3.4', 'myhost.com')
-    resp = response(host='http://1.2.3.4')
-    name = talisker.requests.get_metric_name(resp)
-    assert name == 'requests.myhost-com.GET.200'
+    req = request(url='/foo/bar', host='http://1.2.3.4:8000')
+    metadata = talisker.requests.collect_metadata(req, None)
+    assert metadata == {
+        'url': 'http://myhost.com:8000/foo/bar',
+        'method': 'GET',
+        'host': 'myhost.com',
+        'ip': '1.2.3.4',
+    }
 
 
-def test_get_metric_name_path_len():
-    resp = response(url='/foo/bar')
-    name = talisker.requests.get_metric_name(resp, 2)
-    assert name == 'requests.example-com.foo.bar.GET.200'
+def test_collect_metadata_request_body():
+    req = request(method='POST', url='/foo/bar', json='"some data"')
+    metadata = talisker.requests.collect_metadata(req, None)
+    assert metadata == {
+        'url': 'http://example.com/foo/bar',
+        'method': 'POST',
+        'host': 'example.com',
+        'request_type': 'application/json',
+        'request_size': 15,
+    }
+
+
+def test_collect_metadata_querystring():
+    req = request(url='/foo/bar?baz=1&qux=data')
+    metadata = talisker.requests.collect_metadata(req, None)
+    assert metadata == {
+        'url': 'http://example.com/foo/bar?',
+        'qs': '?baz=<len 1>&qux=<len 4>',
+        'qs_size': 14,
+        'method': 'GET',
+        'host': 'example.com',
+    }
+
+
+def test_collect_metadata_with_response():
+    req = request(url='/foo/bar')
+    resp = response(req, view='views.name', body='some content')
+    metadata = talisker.requests.collect_metadata(req, resp)
+    assert metadata == {
+        'url': 'http://example.com/foo/bar',
+        'method': 'GET',
+        'host': 'example.com',
+        'status_code': 200,
+        'view': 'views.name',
+        'server': 'test/1.0',
+        'duration': 1000,
+        'response_type': 'text/plain',
+        'response_size': 12,
+    }
 
 
 def test_metric_hook(statsd_metrics):
-    r = response()
+    r = response(view='view.name')
 
     with raven.context.Context() as ctx:
         talisker.requests.metrics_response_hook(r)
 
-    assert statsd_metrics[0] == 'requests.example-com.GET.200:1000.000000|ms'
+    assert statsd_metrics[0] == (
+        'requests.example-com.view.name.GET.200:1000.000000|ms'
+    )
     breadcrumbs = ctx.breadcrumbs.get_buffer()
     assert breadcrumbs[0]['type'] == 'http'
     assert breadcrumbs[0]['category'] == 'requests'
     assert breadcrumbs[0]['data']['url'] == 'http://example.com/'
+    assert breadcrumbs[0]['data']['host'] == 'example.com'
+    assert breadcrumbs[0]['data']['method'] == 'GET'
+    assert breadcrumbs[0]['data']['view'] == 'view.name'
+    assert breadcrumbs[0]['data']['status_code'] == 200
+    assert breadcrumbs[0]['data']['duration'] == 1000.0
+
+
+def test_metric_hook_user_name(statsd_metrics):
+    r = response(view='view.name')
+
+    with raven.context.Context() as ctx:
+        talisker.requests._local.metric_api_name = 'my_api_name'
+        talisker.requests._local.metric_host_name = 'service'
+        talisker.requests.metrics_response_hook(r)
+        release_local(talisker.requests._local)
+
+    assert statsd_metrics[0] == (
+        'requests.service.my_api_name.GET.200:1000.000000|ms'
+    )
+    breadcrumbs = ctx.breadcrumbs.get_buffer()
+    assert breadcrumbs[0]['type'] == 'http'
+    assert breadcrumbs[0]['category'] == 'requests'
+    assert breadcrumbs[0]['data']['url'] == 'http://example.com/'
+    assert breadcrumbs[0]['data']['host'] == 'example.com'
+    assert breadcrumbs[0]['data']['view'] == 'view.name'
     assert breadcrumbs[0]['data']['method'] == 'GET'
     assert breadcrumbs[0]['data']['status_code'] == 200
     assert breadcrumbs[0]['data']['duration'] == 1000.0
@@ -83,19 +168,28 @@ def test_configured_session(statsd_metrics, ):
     session = requests.Session()
     talisker.requests.configure(session)
 
-    responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
+    responses.add(
+        responses.GET,
+        'http://localhost/foo/bar',
+        body='OK',
+        headers={'X-View-Name': 'view.name'},
+    )
 
     with talisker.request_id.context('XXX'):
         with raven.context.Context() as ctx:
             session.get('http://localhost/foo/bar')
 
     assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
-    assert statsd_metrics[0].startswith('requests.localhost.GET.200:')
+    assert statsd_metrics[0].startswith(
+        'requests.localhost.view.name.GET.200:',
+    )
     breadcrumbs = ctx.breadcrumbs.get_buffer()
 
     assert breadcrumbs[0]['type'] == 'http'
     assert breadcrumbs[0]['category'] == 'requests'
     assert breadcrumbs[0]['data']['url'] == 'http://localhost/foo/bar'
+    assert breadcrumbs[0]['data']['host'] == 'localhost'
+    assert breadcrumbs[0]['data']['view'] == 'view.name'
     assert breadcrumbs[0]['data']['method'] == 'GET'
     assert breadcrumbs[0]['data']['status_code'] == 200
     assert 'duration' in breadcrumbs[0]['data']
@@ -107,47 +201,31 @@ def test_configured_session_connection_error(statsd_metrics):
 
     with raven.context.Context() as ctx:
         with pytest.raises(requests.exceptions.ConnectionError):
-            session.get('http://nowhere/')
+            session.get('http://nowhere.doesnotexist/foo', )
 
     breadcrumbs = ctx.breadcrumbs.get_buffer()
     assert breadcrumbs[-1]['type'] == 'http'
     assert breadcrumbs[-1]['category'] == 'requests'
-    assert breadcrumbs[-1]['data']['url'] == 'http://nowhere/'
+    assert breadcrumbs[-1]['data']['url'] == 'http://nowhere.doesnotexist/foo'
+    assert breadcrumbs[-1]['data']['host'] == 'nowhere.doesnotexist'
     assert breadcrumbs[-1]['data']['method'] == 'GET'
-    assert 'ConnectionError' in breadcrumbs[-1]['data']['exception']
+    # error code depends if we are running tests with network or not
+    assert breadcrumbs[-1]['data']['errno'] in ('EAI_NONAME', 'EAI_AGAIN')
 
 
 @responses.activate
-def test_configured_session_disable_metrics(statsd_metrics):
+def test_configured_session_with_user_name(statsd_metrics):
     session = requests.Session()
     talisker.requests.configure(session)
 
     responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
 
     with talisker.request_id.context('XXX'):
-        session.get('http://localhost/foo/bar', emit_metric=False)
+        session.get(
+            'http://localhost/foo/bar',
+            metric_api_name='api',
+            metric_host_name='service',
+        )
 
     assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
-    assert len(statsd_metrics) == 0
-
-
-@responses.activate
-def test_configured_session_with_url_metrics(statsd_metrics):
-    session = requests.Session()
-    talisker.requests.configure(session)
-
-    responses.add(responses.GET, 'http://localhost/foo/bar', body='OK')
-
-    with talisker.request_id.context('XXX'):
-        session.get('http://localhost/foo/bar', metric_path_len=1)
-        session.get('http://localhost/foo/bar', metric_path_len=2)
-        session.get('http://localhost/foo/bar')
-
-    assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
-    assert statsd_metrics[0].startswith('requests.localhost.foo.GET.200:')
-
-    assert responses.calls[1].request.headers['X-Request-Id'] == 'XXX'
-    assert statsd_metrics[1].startswith('requests.localhost.foo.bar.GET.200:')
-
-    assert responses.calls[2].request.headers['X-Request-Id'] == 'XXX'
-    assert statsd_metrics[2].startswith('requests.localhost.GET.200:')
+    assert statsd_metrics[0].startswith('requests.service.api.GET.200:')


### PR DESCRIPTION
 - remove previous attempts at controlling metric name, instead can just
 set metric_{api,host}_name kwargs
 - use view name from header if possible for metrics
 - better handling of custom dns names for metrics
 - redact querystring from logging/breadcrumbs
 - include errno fields in logging/breadcrumbs
 - metric for connection errors using new errno support
