### PR TITLE
Simple colorscheme support

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -10,23 +10,22 @@ Talisker's default configuration is designed for production usage, e.g.:
  - python's warning system is disabled
 
 
-Devel Mode
+DEVEL Mode
 ----------
 
-If stderr is a tty, Talisker will run in devel mode. Additionally, if the DEVEL
-env var is set, it will run in devel mode.
+If the DEVEL env var is set, Talisker will run in DEVEL mode.
 
 What this means varies on which tool you are using, but at a base level it
 enables python's warning logs, as you generally want these in development.
 
-For Gunicorn, devel mode means a few more things:
+For Gunicorn, DEVEL mode means a few more things:
 
  - enables access logs to stderr
  - sets timeout to 99999, to avoid timeouts when debugging
  - it enables auto reloading on code changes
 
-Also, for convenience, it you manually set Gunicorn's debug level to DEBUG, when
-in devel mode, Talisker will actually log debug level messages to stderr.
+Also, for developer convenience, it you manually set Gunicorn's debug level to DEBUG, when
+in DEVEL mode, Talisker will actually log debug level messages to stderr.
 
 
 Development Logging
@@ -43,3 +42,24 @@ This includes:
 
  - if stderr is an interactive tty, then logs are colorized, to aid human reading.
 
+
+Colored Output
+--------------
+
+If in DEVEL mode, and stdout is a tty device, then Talisker will colorise log output.
+
+To disable this, you can set the env var:
+
+.. code-block:: bash
+
+    TALISKER_COLOR=no
+
+The colorscheme looks best on dark terminal backgrounds, but should be readable on
+light terminals too.
+
+If your terminal doesn't support bold, dim, or italic text formatting, it might
+look unpleasent. In that case, you can try the simple colors
+
+.. code-block:: bash
+
+    TALISKER_COLOR=simple

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -24,7 +24,7 @@ For Gunicorn, DEVEL mode means a few more things:
  - sets timeout to 99999, to avoid timeouts when debugging
  - it enables auto reloading on code changes
 
-Also, for developer convenience, it you manually set Gunicorn's debug level to DEBUG, when
+Also, for developer convenience, if you manually set Gunicorn's debug level to DEBUG, when
 in DEVEL mode, Talisker will actually log debug level messages to stderr.
 
 
@@ -58,7 +58,7 @@ The colorscheme looks best on dark terminal backgrounds, but should be readable 
 light terminals too.
 
 If your terminal doesn't support bold, dim, or italic text formatting, it might
-look unpleasent. In that case, you can try the simple colors
+look unpleasent. In that case, you can try the simpler colors
 
 .. code-block:: bash
 

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -56,7 +56,8 @@ def initialise(env=os.environ):
     return config
 
 
-ACTIVE = set(['true', '1', 'yes'])
+ACTIVE = set(['true', '1', 'yes', 'on'])
+INACTIVE = set(['false', '0', 'no', 'off'])
 
 
 def get_config(env=os.environ):
@@ -65,9 +66,15 @@ def get_config(env=os.environ):
     color = False
     if devel:
         if 'TALISKER_COLOR' in env:
-            color = env.get('TALISKER_COLOR', '').lower() in ACTIVE
+            color_name = env['TALISKER_COLOR'].lower()
+            if color_name in ACTIVE:
+                color = 'default'
+            elif color_name in INACTIVE:
+                color = False
+            else:
+                color = color_name
         else:
-            color = sys.stderr.isatty()
+            color = 'default' if sys.stderr.isatty() else False
     # log all queries in devel by default
     default_query_time = '0' if devel else '-1'
     return {

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -106,7 +106,7 @@ def configure(config):  # pragma: no cover
     set_logger_class()
     formatter = StructuredFormatter()
     if config['color']:
-        formatter = ColoredFormatter()
+        formatter = ColoredFormatter(style=config['color'])
 
     # always INFO to stderr
     add_talisker_handler(logging.INFO, get_talisker_handler(), formatter)
@@ -490,36 +490,53 @@ class StructuredFormatter(logging.Formatter):
         return s
 
 
+DEFAULT_COLORS = {
+    'logfmt': '2;3;36',     # dim italic teal
+    'name': '0;33',         # orange
+    'msg': '1;16',          # bold white/black, depending on terminal palette
+    'time': '2;34',         # dim dark blue
+    'DEBUG': '0;32',        # green
+    'INFO': '0;32',         # green
+    'WARNING': '0;33',      # orange
+    'ERROR': '0;31',        # red
+    'CRITICAL': '0;31',     # red
+}
+
+
+COLOR_SCHEMES = {}
+COLOR_SCHEMES['default'] = DEFAULT_COLORS
+
+# simple strips italics/bold
+COLOR_SCHEMES['simple'] = DEFAULT_COLORS.copy()
+COLOR_SCHEMES['simple']['logfmt'] = '0;36'
+COLOR_SCHEMES['simple']['msg'] = '0;37'
+COLOR_SCHEMES['simple']['time'] = '0;34'
+
+
 class ColoredFormatter(StructuredFormatter):
     """Colorized log formatting"""
-
-    COLOR_LOGFMT = '\x1b[3;36m'
-    COLOR_NAME = '\x1b[0;33m'
-    COLOR_MSG = '\x1b[1;37m'
-    COLOR_TIME = '\x1b[2;34m'
     CLEAR = '\x1b[0m'
 
-    COLOR_LEVEL = {
-        'DEBUG': '\x1b[0;32m',
-        'INFO': '\x1b[0;32m',
-        'WARNING': '\x1b[0;33m',
-        'ERROR': '\x1b[0;31m',
-        'CRITICAL': '\x1b[0;31m',
-    }
-
-    FORMAT = (
-        COLOR_TIME + '%(asctime)s.%(msecs)03dZ ' + CLEAR +
-        '%(colored_levelname)s ' +
-        COLOR_NAME + '%(name)s ' + CLEAR +
-        '"' + COLOR_MSG + '%(message)s' + CLEAR + '"'
-    )
+    def __init__(self, style='default'):
+        style = COLOR_SCHEMES[style]
+        self.colors = {k: '\x1b[' + v + 'm' for k, v in style.items()}
+        format = (
+            '{time}%(asctime)s.%(msecs)03dZ{clear} '
+            '%(colored_levelname)s '
+            '{name}%(name)s{clear} '
+            '"{msg}%(message)s{clear}'
+        ).format(clear=self.CLEAR, **self.colors)
+        super().__init__(fmt=format)
 
     def format(self, record):
-        record.colored_levelname = (
-            self.COLOR_LEVEL[record.levelname] +
-            record.levelname + self.CLEAR)
+        color = self.colors[record.levelname]
+        record.colored_levelname = '{color}{levelname}{clear}'.format(
+            color=color,
+            levelname=record.levelname,
+            clear=self.CLEAR,
+        )
         return super(ColoredFormatter, self).format(record)
 
     def logfmt(self, structured):
         logfmt_str = super(ColoredFormatter, self).logfmt(structured)
-        return self.COLOR_LOGFMT + logfmt_str + self.CLEAR
+        return self.colors['logfmt'] + logfmt_str + self.CLEAR

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -56,11 +56,16 @@ def test_get_config(monkeypatch):
     assert_config(
         {'DEVEL': '1', 'TALISKER_COLOR': '1'},
         devel=True,
-        color=True,
+        color='default',
+    )
+    assert_config(
+        {'DEVEL': '1', 'TALISKER_COLOR': 'simple'},
+        devel=True,
+        color='simple',
     )
 
     monkeypatch.setattr(sys.stderr, 'isatty', lambda: True)
-    assert_config({'DEVEL': '1'}, devel=True, color=True)
+    assert_config({'DEVEL': '1'}, devel=True, color='default')
     assert_config(
         {'DEVEL': '1', 'TALISKER_COLOR': '0'},
         devel=True,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -269,16 +269,13 @@ def test_formatter_large_msg(monkeypatch):
 
 
 def test_colored_formatter():
-    CF = logs.ColoredFormatter
-    assert CF.COLOR_TIME in CF.FORMAT
-    assert CF.COLOR_NAME in CF.FORMAT
-    assert CF.COLOR_MSG in CF.FORMAT
-    fmt = CF()
+    fmt = logs.ColoredFormatter()
     record = make_record({})
-    fmt.format(record)
-    assert CF.COLOR_LEVEL['INFO'] in record.colored_levelname
+    output = fmt.format(record)
+    assert logs.DEFAULT_COLORS['time'] in output
+    assert logs.DEFAULT_COLORS['INFO'] in record.colored_levelname
     logfmt = fmt.logfmt({'foo': 'bar'})
-    assert CF.COLOR_LOGFMT in logfmt
+    assert logs.DEFAULT_COLORS['logfmt'] in logfmt
 
 
 def assert_output_includes_message(err, msg):
@@ -344,7 +341,7 @@ def test_configure_debug_log(config, log):
 
 
 def test_configure_colored(config, log, monkeypatch):
-    config['color'] = True
+    config['color'] = 'default'
     logs.configure(config)
     assert isinstance(
         logs.get_talisker_handler().formatter, logs.ColoredFormatter)


### PR DESCRIPTION
Disables use of italics/bold/dim text formatting in colorisation, and better support for light terminal backgrounds