### PR TITLE
Ensure that configured sentry processors is a set

### DIFF
--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -72,9 +72,9 @@ def update_client_references(client):
 
 def ensure_talisker_config(kwargs):
     # ensure default processors
-    processors = kwargs.get('processors')
-    if not processors:
-        processors = set([])
+    # this is provided as a list from settings, but we need a set
+    # to ensure we don't duplicate
+    processors = set(kwargs.get('processors', []))
     kwargs['processors'] = list(default_processors | processors)
 
     # override it or it interferes with talisker logging


### PR DESCRIPTION
The configuration options for raven provide the processors as a list, we need it to be a set before we can perform operations on it.