### PR TITLE
resolver_match might not be set

### DIFF
--- a/talisker/django.py
+++ b/talisker/django.py
@@ -55,6 +55,7 @@ def middleware(get_response):
     """Set up middleware to add X-View-Name header."""
     def add_view_name(request):
         response = get_response(request)
-        response['X-View-Name'] = request.resolver_match.view_name
+        if request.resolver_match:
+            response['X-View-Name'] = request.resolver_match.view_name
         return response
     return add_view_name

--- a/talisker/django.py
+++ b/talisker/django.py
@@ -55,7 +55,7 @@ def middleware(get_response):
     """Set up middleware to add X-View-Name header."""
     def add_view_name(request):
         response = get_response(request)
-        if request.resolver_match:
+        if getattr(request, 'resolver_match', None):
             response['X-View-Name'] = request.resolver_match.view_name
         return response
     return add_view_name


### PR DESCRIPTION
If the middleware chain hasn't executed, or has been bypassed (such as a 404), `resolver_match` may not be set, so we can't add the `X-View-Name` header.