### PR TITLE
Change default slow query threshold to -1, unless overriden

### DIFF
--- a/docs/postgresql.rst
+++ b/docs/postgresql.rst
@@ -57,8 +57,9 @@ Slow query Logging
 
 The connection logs slow queries to the `talisker.slowqueries` logger. The
 default timeout is -1, which disables slow query logging, but can be controlled with the
-TALISKER_SLOWQUERY_THRESHOLD env var. If DEVEL envvar is set, the default is 0, and
-Talisker will log every query.
+TALISKER_SLOWQUERY_THRESHOLD env var. The value is measured in milliseconds::
+
+    export TALISKER_SLOWQUERY_THRESHOLD=100  # log queries over 100ms
 
 
 Sentry Breadcrumbs

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -75,8 +75,8 @@ def get_config(env=os.environ):
                 color = color_name
         else:
             color = 'default' if sys.stderr.isatty() else False
-    # log all queries in devel by default
-    default_query_time = '0' if devel else '-1'
+    # disable query logging by default, prevent log spamming
+    default_query_time = '-1'
     return {
         'devel': devel,
         'color': color,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -52,7 +52,10 @@ def test_get_config(monkeypatch):
     assert_config(
         {'TALISKER_SLOWQUERY_THRESHOLD': '3000'}, slowquery_threshold=3000)
 
-    assert_config({'DEVEL': '1'}, devel=True, slowquery_threshold=0)
+    assert_config({'DEVEL': '1'}, devel=True, slowquery_threshold=-1)
+    assert_config(
+        {'DEVEL': '1', 'TALISKER_SLOWQUERY_THRESHOLD': '3000'},
+        devel=True, slowquery_threshold=3000)
     assert_config(
         {'DEVEL': '1', 'TALISKER_COLOR': '1'},
         devel=True,


### PR DESCRIPTION
Having the default to be 0 in DEVEL is too verbose, disable slow query logging unless overriden by the env var.

* Update the docs to add an example and units
* Add assert to test to check we can still override in DEVEL