### PR TITLE
add soft request timeout support

### DIFF
--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -83,6 +83,8 @@ def get_config(env=os.environ):
         'debuglog': env.get('DEBUGLOG'),
         'slowquery_threshold': int(
             env.get('TALISKER_SLOWQUERY_THRESHOLD', default_query_time)),
+        'soft_request_timeout': int(
+            env.get('TALISKER_SOFT_REQUEST_TIMEOUT', default_query_time)),
         'logstatus': env.get('TALISKER_LOGSTATUS', '').lower() in ACTIVE
     }
 

--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -25,6 +25,7 @@ import logging
 import os
 import time
 
+import flask
 import raven
 import raven.middleware
 import raven.handlers.logging
@@ -174,6 +175,10 @@ class TaliskerSentryMiddleware(raven.middleware.Sentry):
                         'Start_response over timeout: {}'
                         .format(soft_start_timeout)
                     )
+                # only clear transaction via url_rule if there is a flask
+                # context
+                if flask.has_request_context() and flask.request.url_rule:
+                    self.client.transaction.pop(flask.request.url_rule.rule)
                 return response
             return super().__call__(environ, soft_timeout_start_response)
         else:

--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -23,6 +23,7 @@ from builtins import *  # noqa
 
 import logging
 import os
+import time
 
 import raven
 import raven.middleware
@@ -159,7 +160,24 @@ class TaliskerSentryMiddleware(raven.middleware.Sentry):
         # we clear the sentry context before the request starts, in order to
         # avoid picking up gunicorn log messages from previous requests
         self.client.context.clear()
-        return super().__call__(environ, start_response)
+        soft_start_timeout = talisker.get_config()['soft_request_timeout']
+        if soft_start_timeout >= 0:
+            # XXX get value of soft_start_timeout from config...how?
+            start_time = time.time()
+
+            def soft_timeout_start_response(status, headers, exc_info=None):
+                response = start_response(status, headers, exc_info=exc_info)
+                duration = (time.time() - start_time) * 1000
+                if (soft_start_timeout is not None and
+                        duration > soft_start_timeout):
+                    self.client.captureMessage(
+                        'Start_response over timeout: {}'
+                        .format(soft_start_timeout)
+                    )
+                return response
+            return super().__call__(environ, soft_timeout_start_response)
+        else:
+            return super().__call__(environ, start_response)
 
 
 @module_cache

--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -25,7 +25,6 @@ import logging
 import os
 import time
 
-import flask
 import raven
 import raven.middleware
 import raven.handlers.logging

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -22,6 +22,8 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 import logging
+import os
+
 from flask import Flask
 
 import talisker.flask
@@ -128,6 +130,21 @@ def test_flask_sentry_not_clear_afer_request(monkeypatch):
     get_url(tapp, '/')
     assert len(calls) == 0
     assert isinstance(sentry, talisker.flask.FlaskSentry)
+
+
+def test_flask_sentry_transaction_clear_afer_request_in_middleware(
+        monkeypatch, environ, sentry_messages):
+    monkeypatch.setitem(os.environ, 'TALISKER_SOFT_REQUEST_TIMEOUT', '0')
+    tapp = Flask(__name__)
+
+    @tapp.route('/')
+    def index():
+        return 'ok'
+
+    sentry = talisker.flask.sentry(tapp)
+    mw = talisker.sentry.get_middleware(tapp.wsgi_app)
+    conftest.run_wsgi(mw, environ)
+    assert sentry.client.transaction.peek() is None
 
 
 def test_talisker_flask_app():

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -132,21 +132,6 @@ def test_flask_sentry_not_clear_afer_request(monkeypatch):
     assert isinstance(sentry, talisker.flask.FlaskSentry)
 
 
-def test_flask_sentry_transaction_clear_afer_request_in_middleware(
-        monkeypatch, environ, sentry_messages):
-    monkeypatch.setitem(os.environ, 'TALISKER_SOFT_REQUEST_TIMEOUT', '0')
-    tapp = Flask(__name__)
-
-    @tapp.route('/')
-    def index():
-        return 'ok'
-
-    sentry = talisker.flask.sentry(tapp)
-    mw = talisker.sentry.get_middleware(tapp.wsgi_app)
-    conftest.run_wsgi(mw, environ)
-    assert sentry.client.transaction.peek() is None
-
-
 def test_talisker_flask_app():
     tapp = talisker.flask.TaliskerApp(__name__)
     logname = getattr(app, 'logger_name', 'flask.app')

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -114,6 +114,22 @@ def test_flask_sentry_app_tag():
     assert msg['tags']['flask_app'] == app.name
 
 
+def test_flask_sentry_not_clear_afer_request(monkeypatch):
+    tapp = Flask(__name__)
+
+    @tapp.route('/')
+    def index():
+        return 'ok'
+
+    sentry = talisker.flask.sentry(tapp)
+    calls = []
+    monkeypatch.setattr(sentry.client.context, 'clear',
+                        lambda: calls.append(1))
+    get_url(tapp, '/')
+    assert len(calls) == 0
+    assert isinstance(sentry, talisker.flask.FlaskSentry)
+
+
 def test_talisker_flask_app():
     tapp = talisker.flask.TaliskerApp(__name__)
     logname = getattr(app, 'logger_name', 'flask.app')

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 import logging
-import os
 
 from flask import Flask
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -186,7 +186,8 @@ def test_middleware_soft_request_timeout(
         return []
 
     mw = talisker.sentry.get_middleware(app)
-    conftest.run_wsgi(mw, environ)
+    body, _, _ = conftest.run_wsgi(mw, environ)
+    list(body)
     assert 'Start_response over timeout: 0' == sentry_messages[0]['message']
 
 
@@ -200,7 +201,8 @@ def test_middleware_soft_request_timeout_non_zero(
         return []
 
     mw = talisker.sentry.get_middleware(app)
-    conftest.run_wsgi(mw, environ)
+    body, _, _ = conftest.run_wsgi(mw, environ)
+    list(body)
     assert 'Start_response over timeout: 100' == sentry_messages[0]['message']
 
 
@@ -211,11 +213,12 @@ def test_middleware_soft_request_timeout_disabled_by_default(
         return []
 
     mw = talisker.sentry.get_middleware(app)
-    conftest.run_wsgi(mw, environ)
+    body, _, _ = conftest.run_wsgi(mw, environ)
+    list(body)
     assert len(sentry_messages) == 0
 
 
-def test_middleware_soft_request_timeout(
+def test_middleware_soft_request_timeout_clear_transaction_stack(
         monkeypatch, environ, sentry_messages):
     monkeypatch.setitem(os.environ, 'TALISKER_SOFT_REQUEST_TIMEOUT', '0')
 
@@ -226,7 +229,8 @@ def test_middleware_soft_request_timeout(
 
     mw = talisker.sentry.get_middleware(app)
     mw.client.transaction.push('test')
-    conftest.run_wsgi(mw, environ)
+    body, _, _ = conftest.run_wsgi(mw, environ)
+    list(body)
     assert 'Start_response over timeout: 0' == sentry_messages[0]['message']
 
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -16,6 +16,7 @@
 
 import os
 import logging
+import time
 
 import talisker.sentry
 import talisker.logs
@@ -174,6 +175,44 @@ def test_middleware_clears_context(environ):
     data = {}
     context.breadcrumbs.buffer[0][1](data)
     assert data['message'] == 'app log'
+
+
+def test_middleware_soft_request_timeout(
+        monkeypatch, environ, sentry_messages):
+    monkeypatch.setitem(os.environ, 'TALISKER_SOFT_REQUEST_TIMEOUT', '0')
+
+    def app(environ, start_response):
+        start_response(200, [])
+        return []
+
+    mw = talisker.sentry.get_middleware(app)
+    conftest.run_wsgi(mw, environ)
+    assert 'Start_response over timeout: 0' == sentry_messages[0]['message']
+
+
+def test_middleware_soft_request_timeout_non_zero(
+        monkeypatch, environ, sentry_messages):
+    monkeypatch.setitem(os.environ, 'TALISKER_SOFT_REQUEST_TIMEOUT', '100')
+
+    def app(environ, start_response):
+        time.sleep(200 / 1000)
+        start_response(200, [])
+        return []
+
+    mw = talisker.sentry.get_middleware(app)
+    conftest.run_wsgi(mw, environ)
+    assert 'Start_response over timeout: 100' == sentry_messages[0]['message']
+
+
+def test_middleware_soft_request_timeout_disabled_by_default(
+        environ, sentry_messages):
+    def app(environ, start_response):
+        start_response(200, [])
+        return []
+
+    mw = talisker.sentry.get_middleware(app)
+    conftest.run_wsgi(mw, environ)
+    assert len(sentry_messages) == 0
 
 
 def test_get_log_handler():

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -196,7 +196,7 @@ def test_middleware_soft_request_timeout_non_zero(
     monkeypatch.setitem(os.environ, 'TALISKER_SOFT_REQUEST_TIMEOUT', '100')
 
     def app(environ, start_response):
-        time.sleep(200 / 1000)
+        time.sleep(200 / 1000.0)
         start_response(200, [])
         return []
 


### PR DESCRIPTION
This creates a sentry message when the duration of the request is longer than soft_request_timeout config value.