### PR TITLE
Move the clearing of various request contexts as late as possible,

### DIFF
--- a/talisker/context.py
+++ b/talisker/context.py
@@ -30,7 +30,6 @@ from collections import OrderedDict
 from contextlib import contextmanager
 
 from werkzeug.local import Local, release_local
-from werkzeug.wsgi import ClosingIterator
 
 # a per request/job context. Generally, this will be the equivalent of thread
 # local storage, but if greenlets are being used it will be a greenlet local.
@@ -39,12 +38,6 @@ context = Local()
 
 def clear():
     release_local(context)
-
-
-def wsgi_middleware(app):
-    def middleware(environ, start_response):
-        return ClosingIterator(app(environ, start_response), clear)
-    return middleware
 
 
 class ContextStack(Mapping):

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -539,7 +539,7 @@ class ColoredFormatter(StructuredFormatter):
             '{time}%(asctime)s.%(msecs)03dZ{clear} '
             '%(colored_levelname)s '
             '{name}%(name)s{clear} '
-            '"{msg}%(message)s{clear}'
+            '"{msg}%(message)s{clear}"'
         ).format(clear=self.CLEAR, **self.colors)
         super().__init__(fmt=format)
 

--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -157,11 +157,6 @@ class TaliskerSentryClient(raven.Client):
 class TaliskerSentryMiddleware(raven.middleware.Sentry):
 
     def __call__(self, environ, start_response):
-        # we clear the sentry context and transaction stack before the request
-        # starts, in order to avoid picking up gunicorn log messages from
-        # previous requests
-        self.client.context.clear()
-        self.client.transaction.clear()
         soft_start_timeout = talisker.get_config()['soft_request_timeout']
         if soft_start_timeout >= 0:
             # XXX get value of soft_start_timeout from config...how?

--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -77,7 +77,6 @@ def wrap(app):
     )
     # add request id info to thread locals
     wrapped = talisker.request_id.RequestIdMiddleware(wrapped)
-    wrapped = talisker.context.wsgi_middleware(wrapped)
     wrapped = talisker.sentry.get_middleware(wrapped)
     wrapped._talisker_wrapped = True
     wrapped._talisker_original_app = app

--- a/tests/flask_app.py
+++ b/tests/flask_app.py
@@ -58,5 +58,6 @@ def error():
 
 @app.route('/nested')
 def nested():
-    resp = talisker.requests.get_session().get('http://localhost:8001')
+    logger.info('here')
+    resp = talisker.requests.get_session().get('http://10.0.4.1:1234')
     return Response(resp.content, status=200, headers=resp.headers.items())


### PR DESCRIPTION
To basically just before another request starts.

This allows the request id and various sentry contexts to last as long
as possible, rather than being cleaned up at the wsgi stage. This means
gunicorn can have that info, and exceptions logged/reported (e.g. worker
timeouts) will have as much context as possible for logs and sentry
reports