### PR TITLE
Fix prometheus multiprocess

### DIFF
--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -27,7 +27,7 @@ import os
 import tempfile
 
 from future.utils import exec_
-from talisker.util import ensure_extra_versions_supported
+from talisker.util import ensure_extra_versions_supported, pkg_is_installed
 
 __version__ = '0.9.10'
 __all__ = [
@@ -46,7 +46,8 @@ def initialise(env=os.environ):
     # set this early so any imports of prometheus client will be imported
     # correctly
     if 'prometheus_multiproc_dir' not in os.environ:
-        os.environ['prometheus_multiproc_dir'] = tempfile.mkdtemp()
+        if pkg_is_installed('prometheus-client'):
+            os.environ['prometheus_multiproc_dir'] = tempfile.mkdtemp()
 
     import talisker.logs
     talisker.logs.configure(config)

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -47,7 +47,8 @@ def initialise(env=os.environ):
     # correctly
     if 'prometheus_multiproc_dir' not in os.environ:
         if pkg_is_installed('prometheus-client'):
-            os.environ['prometheus_multiproc_dir'] = tempfile.mkdtemp()
+            tmp = tempfile.mkdtemp(prefix='prometheus_multiproc')
+            os.environ['prometheus_multiproc_dir'] = tmp
 
     import talisker.logs
     talisker.logs.configure(config)

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -24,6 +24,7 @@ from builtins import *  # noqa
 import logging
 import sys
 import os
+import tempfile
 
 from future.utils import exec_
 from talisker.util import ensure_extra_versions_supported
@@ -42,6 +43,11 @@ __all__ = [
 
 def initialise(env=os.environ):
     config = get_config(env)
+    # set this early so any imports of prometheus client will be imported
+    # correctly
+    if 'prometheus_multiproc_dir' not in os.environ:
+        os.environ['prometheus_multiproc_dir'] = tempfile.mkdtemp()
+
     import talisker.logs
     talisker.logs.configure(config)
     # now that logging is set up, initialise other modules

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -274,9 +274,9 @@ class TaliskerApplication(WSGIApplication):
                 extra={'logger_class': self.cfg.logger_class})
         # Use pip to find out if prometheus_client is available, as
         # importing it here would break multiprocess metrics
-        dir = os.environ.get('prometheus_multiproc_dir')
-        if pkg_is_installed('prometheus-client') and dir is not None:
+        multidir = os.environ.get('prometheus_multiproc_dir')
+        if pkg_is_installed('prometheus-client') and multidir is not None:
             logger.info(
                 'prometheus_client is in multiprocess mode',
-                extra={'prometheus_multiproc_dir': dir},
+                extra={'prometheus_multiproc_dir': multidir},
             )

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -24,7 +24,6 @@ from builtins import *  # noqa
 from collections import OrderedDict
 import logging
 import os
-import tempfile
 
 from gunicorn.glogging import Logger
 from gunicorn.app.wsgiapp import WSGIApplication
@@ -275,13 +274,9 @@ class TaliskerApplication(WSGIApplication):
                 extra={'logger_class': self.cfg.logger_class})
         # Use pip to find out if prometheus_client is available, as
         # importing it here would break multiprocess metrics
-        if (pkg_is_installed('prometheus-client') and
-                (self.cfg.workers or 1) > 1):
-            if 'prometheus_multiproc_dir' not in os.environ:
-                logger.info('running in multiprocess mode but '
-                            '`prometheus_multiproc_dir` envvar not set')
-                tmpdir = tempfile.mkdtemp()
-                os.environ['prometheus_multiproc_dir'] = tmpdir
-
-            logger.info('using `%s` for multiprocess prometheus metrics',
-                        os.environ['prometheus_multiproc_dir'])
+        dir = os.environ.get('prometheus_multiproc_dir')
+        if pkg_is_installed('prometheus-client') and dir is not None:
+            logger.info(
+                'prometheus_client is in multiprocess mode',
+                extra={'prometheus_multiproc_dir': dir},
+            )

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 import os
+from time import sleep
 
 import pytest
 import requests
@@ -107,5 +108,7 @@ def test_multiprocess_metrics(tmpdir):
 
         for i in range(1, 4):
             requests.get(inc)
+            # try ensure the update is written before we read it
+            sleep(0.3)
             response = requests.get(read)
             assert get_count(response) == float(initial + i)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -100,7 +100,12 @@ def test_multiprocess_metrics(tmpdir):
     with GunicornProcess(APP, args=['-w', '2'], env=env) as p:
         inc = p.url('/_status/test/prometheus')
         read = p.url('/_status/metrics')
+        response = requests.get(read)
+        initial = get_count(response)
+        if initial is None:
+            initial = 0
+
         for i in range(1, 4):
             requests.get(inc)
             response = requests.get(read)
-            assert get_count(response) == float(i)
+            assert get_count(response) == float(initial + i)


### PR DESCRIPTION
prometheus_client needs the env var 'prometheus_multiproc_dir' set when it is imported, or else it imports in normal mode, not multiprocess mode. So we set this early. 

This does mean that we are always in multiprocess mode, even when we only have one worker, but I'm ok with that, as one worker is not an interesting use case for us.

There's also a driveby fix to get tests passing, as DNS config of the host made the test fail.