### PR TITLE
Fix X-Request-Id to be a native string on py2

### DIFF
--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -27,7 +27,7 @@ import logging
 import threading
 
 from future.moves.urllib.parse import parse_qsl
-from future.utils import native
+from future.utils import text_to_native_str
 import raven.breadcrumbs
 import requests
 import werkzeug.local
@@ -44,7 +44,7 @@ __all__ = [
 ]
 
 # wsgi requires native strings
-HEADER = native(request_id.HEADER)
+HEADER = text_to_native_str(request_id.HEADER)
 storage = threading.local()
 storage.sessions = {}
 HOSTS = {}

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -181,6 +181,8 @@ def test_configured_session(statsd_metrics):
         with raven.context.Context() as ctx:
             session.get('http://localhost/foo/bar')
 
+    for header_name in responses.calls[0].request.headers:
+        assert isinstance(header_name, str)
     assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
     assert statsd_metrics[0] == 'requests.count.localhost.view:1|c'
     assert statsd_metrics[1].startswith(
@@ -275,6 +277,8 @@ def test_configured_session_with_user_name(statsd_metrics):
             metric_host_name='service',
         )
 
+    for header_name in responses.calls[0].request.headers:
+        assert isinstance(header_name, str)
     assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
     assert statsd_metrics[0].startswith('requests.count.service.api:')
     assert statsd_metrics[1].startswith('requests.latency.service.api.200:')


### PR DESCRIPTION
`future.utils.native` doesn't convert unicode to str on Python 2; the
function we need for that is `future.utils.text_to_native_str`.  This
caused requests with non-ASCII bodies to fail due to trying to
concatenate a unicode object with a non-ASCII str.

This is tough to test end-to-end because responses hooks in high enough
to mask the crash in httplib, but testing that all header names are
native strings should at least be enough to stop it regressing.

This bug was introduced in 0.9.6.