### PR TITLE
set level=warning in soft req. timeout sentry message

### DIFF
--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -169,7 +169,8 @@ class TaliskerSentryMiddleware(raven.middleware.Sentry):
                         duration > soft_start_timeout):
                     self.client.captureMessage(
                         'Start_response over timeout: {}'
-                        .format(soft_start_timeout)
+                        .format(soft_start_timeout),
+                        level='warning'
                     )
                 return response
             return super().__call__(environ, soft_timeout_start_response)

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -168,6 +168,7 @@ def test_middleware_soft_request_timeout(
     body, _, _ = conftest.run_wsgi(mw, environ)
     list(body)
     assert 'Start_response over timeout: 0' == sentry_messages[0]['message']
+    assert 'warning' == sentry_messages[0]['level']
 
 
 def test_middleware_soft_request_timeout_non_zero(


### PR DESCRIPTION
change the level, from the default: error, to warning in the soft request timeout caputreMessage call.