### PR TITLE
- Do no swallow the Sentry capture's result.

### DIFF
--- a/talisker/django.py
+++ b/talisker/django.py
@@ -48,7 +48,7 @@ class SentryClient(DjangoClient):
 
     def capture(self, event_type, tags=None, extra=None, **kwargs):
         tags, extra = talisker.sentry.add_talisker_context(tags, extra)
-        super().capture(event_type, tags=tags, extra=extra, **kwargs)
+        return super().capture(event_type, tags=tags, extra=extra, **kwargs)
 
 
 def middleware(get_response):


### PR DESCRIPTION
Fixes #257.
Simon, this needs a test but I'm proposing the change so this issue is raised to your attention.