### PR TITLE
Add support for TALISKER_REVISION_ID variable

### DIFF
--- a/talisker/revision.py
+++ b/talisker/revision.py
@@ -14,6 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import os
 import subprocess
 import sys
 
@@ -36,6 +37,10 @@ def _run(args):
 def version_info_txt():
     with open('version-info.txt', 'rb') as f:
         return f.read()
+
+
+def talisker_revision_id():
+    return os.environ.get('TALISKER_REVISION_ID').encode('utf-8')
 
 
 def git():
@@ -62,6 +67,7 @@ def setup_py():
 
 revision_funcs = [
     version_info_txt,
+    talisker_revision_id,
     git,
     bzr,
     bzr_version_info,

--- a/tests/test_revision.py
+++ b/tests/test_revision.py
@@ -109,6 +109,14 @@ def test_version_info(monkeypatch):
     assert rev == '1'
 
 
+def test_talisker_revision_id(monkeypatch):
+    dir = tempfile.mkdtemp()
+    monkeypatch.chdir(dir)
+    monkeypatch.setenv('TALISKER_REVISION_ID', '7')
+    rev = revision.get.uncached()
+    assert rev == '7'
+
+
 def test_setup_py(monkeypatch, capsys):
     setup_py = textwrap.dedent("""
     from distutils.core import setup


### PR DESCRIPTION
This can be used instead of `version-info.txt` or other methods of
determining the revision ID.

Fixes #195