### PR TITLE
Aggregate prometheus metrics into one file on worker death.

### DIFF
--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -169,13 +169,17 @@ def run_celery(argv=sys.argv):
     main(argv)
 
 
-def run_gunicorn():
-    # set this early so any imports of prometheus client will be imported
-    # correctly
+def setup_multiproc_dir():
     if 'prometheus_multiproc_dir' not in os.environ:
         if pkg_is_installed('prometheus-client'):
             tmp = tempfile.mkdtemp(prefix='prometheus_multiproc')
             os.environ['prometheus_multiproc_dir'] = tmp
+
+
+def run_gunicorn():
+    # set this early so any imports of prometheus client will be imported
+    # correctly
+    setup_multiproc_dir()
     config = initialise()
     import talisker.celery
     import talisker.gunicorn

--- a/talisker/endpoints.py
+++ b/talisker/endpoints.py
@@ -126,9 +126,9 @@ def ok_response():
 @module_cache
 def test_counter():
     # this is created lazily as we may not have prometheus installed.
-    # Also, isolate in it's own registry. Multiprocess mode doesn't really use
+    # Also, isolate in its own registry. Multiprocess mode doesn't really use
     # registries, but it helps keep things separated, which is useful in
-    # testing
+    # testing.
     import prometheus_client
     registry = prometheus_client.CollectorRegistry()
     return prometheus_client.Counter('test', 'test', registry=registry)

--- a/talisker/endpoints.py
+++ b/talisker/endpoints.py
@@ -129,9 +129,8 @@ def test_counter():
     # Also, isolate in its own registry. Multiprocess mode doesn't really use
     # registries, but it helps keep things separated, which is useful in
     # testing.
-    import prometheus_client
-    registry = prometheus_client.CollectorRegistry()
-    return prometheus_client.Counter('test', 'test', registry=registry)
+    from prometheus_client import Counter, CollectorRegistry
+    return Counter('test', 'test', registry=CollectorRegistry())
 
 
 class StandardEndpointMiddleware(object):

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -81,7 +81,7 @@ class GunicornMetric:
     )
 
 
-def prometheus_multiprocess_worker_exit(server, worker):
+def prometheus_multiprocess_child_exit(server, worker):
     """Default worker cleanup function for multiprocess prometheus_client."""
     if 'prometheus_multiproc_dir' in os.environ:
         logging.getLogger(__name__).info(
@@ -230,7 +230,7 @@ class TaliskerApplication(WSGIApplication):
         # Use pip to find out if prometheus_client is available, as
         # importing it here would break multiprocess metrics
         if pkg_is_installed('prometheus-client'):
-            cfg['worker_exit'] = prometheus_multiprocess_worker_exit
+            cfg['child_exit'] = prometheus_multiprocess_child_exit
 
         # development config
         if self._devel:

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -86,8 +86,7 @@ def prometheus_multiprocess_worker_exit(server, worker):
     if 'prometheus_multiproc_dir' in os.environ:
         logging.getLogger(__name__).info(
             'Performing multiprocess prometheus_client cleanup')
-        from prometheus_client import multiprocess
-        multiprocess.mark_process_dead(worker.pid)
+        talisker.metrics.prometheus_cleanup_worker(worker.pid)
 
 
 def gunicorn_pre_request(worker, req):

--- a/talisker/metrics.py
+++ b/talisker/metrics.py
@@ -303,14 +303,18 @@ def write_metrics(metrics, histogram_file, counter_file):
     histograms = _MmapedDict(histogram_file)
     counters = _MmapedDict(counter_file)
 
-    for metric in metrics:
-        if metric.type == 'histogram':
-            sink = histograms
-        elif metric.type == 'counter':
-            sink = counters
+    try:
+        for metric in metrics:
+            if metric.type == 'histogram':
+                sink = histograms
+            elif metric.type == 'counter':
+                sink = counters
 
-        for name, labels, value in metric.samples:
-            key = json.dumps(
-                (metric.name, name, tuple(labels), tuple(labels.values()))
-            )
-            sink.write_value(key, value)
+            for name, labels, value in metric.samples:
+                key = json.dumps(
+                    (metric.name, name, tuple(labels), tuple(labels.values()))
+                )
+                sink.write_value(key, value)
+    finally:
+        histograms.close()
+        counters.close()

--- a/talisker/metrics.py
+++ b/talisker/metrics.py
@@ -198,21 +198,22 @@ def prometheus_cleanup_worker(pid):
 def collect(files):
     """This almost verbatim from MultiProcessCollector.collect().
 
-    It differs in a few ways:
+    The original collects all results in a format designed to be scraped. We
+    instead need to collect limited results, in a format that can be written
+    back to disk. To facilitate this, this version of collect() preserves label
+    ordering, and does aggregate the histograms.
 
-    1. it takes its files as an argument, rather than hardcoding '*.db', and
-       skips none existent files
-    2. it does not accumulate histograms, as it is intended for writing that
-       data back out
-    3. it uses an OrderedDict to preserve label order, and thus metric identity
+    Specifically, it differs from the original:
+
+    1. it takes its files as an argument, rather than hardcoding '*.db'
+    2. it does not accumulate histograms
+    3. it uses an OrderedDict to preserve label order
 
     It needs to be kept up to date with changes to prometheus_client as much as
     possible, or until changes are landed upstream to allow better reuse.
     """
     metrics = {}
     for f in files:
-        if not os.path.exists(f):
-            continue
         # verbatim from here...
         parts = os.path.basename(f).split('_')
         typ = parts[0]

--- a/talisker/metrics.py
+++ b/talisker/metrics.py
@@ -163,9 +163,10 @@ def prometheus_cleanup_worker(pid):
             'counter_{}.db'.format(pid),
         ]
         paths = [os.path.join(prom_dir, f) for f in worker_files]
+        paths = [p for p in paths if os.path.exists(p)]
 
         # check at least one worker file exists
-        if not any(os.path.exists(path) for path in paths):
+        if not paths:
             return
 
         files = [
@@ -184,8 +185,7 @@ def prometheus_cleanup_worker(pid):
             tmp_counter.name, os.path.join(prom_dir, counter_archive))
 
         for path in paths:
-            if os.path.exists(path):
-                os.unlink(path)
+            os.unlink(path)
 
     except Exception:
         # we should never fail at cleaning up

--- a/talisker/metrics.py
+++ b/talisker/metrics.py
@@ -41,7 +41,6 @@ import talisker.statsd
 
 try:
     import prometheus_client
-    from prometheus_client import core, multiprocess
 except ImportError:
     prometheus_client = False
 
@@ -153,10 +152,10 @@ def prometheus_cleanup_worker(pid):
     """Clean up after a multiprocess worker has died."""
     if not prometheus_client:
         return
+    from prometheus_client.multiprocess import mark_process_dead
 
     try:
-        # just deletes gauge files
-        multiprocess.mark_process_dead(pid)
+        mark_process_dead(pid)  # just deletes gauge files
         prom_dir = os.environ['prometheus_multiproc_dir']
         worker_files = [
             'histogram_{}.db'.format(pid),
@@ -212,6 +211,7 @@ def collect(files):
     It needs to be kept up to date with changes to prometheus_client as much as
     possible, or until changes are landed upstream to allow better reuse.
     """
+    from prometheus_client import core
     metrics = {}
     for f in files:
         # verbatim from here...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,16 +29,22 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
+# make sure prometheus is setup in multiprocess mode. We don't actuall use this
+# dir in tests, as each test gets it's own directory, but this ensures
+# prometheus_client is imported in multiprocess mode
+from talisker import setup_multiproc_dir
+setup_multiproc_dir()
+
 # do this as early as possible, to set up logging in pytest
 import talisker.logs
 talisker.logs.configure_test_logging()
 
 import ast
 import logging
-import os
-import zlib
 import json
+import os
 from wsgiref.util import setup_testing_defaults
+import zlib
 
 import pytest
 
@@ -57,13 +63,17 @@ import talisker.sentry
 
 
 @pytest.yield_fixture(autouse=True)
-def clean_up():
+def clean_up(tmpdir, monkeypatch):
     """Clean up all globals.
 
     Sadly, talisker uses some global state.  Namely, stdlib logging module
     globals and thread/greenlet locals. This fixure ensures they are all
     cleaned up each time.
     """
+
+    multiproc = tmpdir.mkdir('multiproc')
+    monkeypatch.setenv('prometheus_multiproc_dir', str(multiproc))
+
     yield
 
     # module/context globals
@@ -74,6 +84,11 @@ def clean_up():
     talisker.context.clear()
     raven.context._active_contexts.__dict__.clear()
     talisker.logs.configure_test_logging()
+
+    # clear prometheus file cache
+    import prometheus_client.core as core
+    # recreate class to clear cache, because cache is a closure...
+    core._ValueClass = core._MultiProcessValue()
 
 
 @pytest.fixture
@@ -120,12 +135,6 @@ def statsd_metrics(monkeypatch):
     client = talisker.statsd.get_client()
     with client.collect() as stats:
         yield stats
-
-
-@pytest.fixture
-def prometheus_metrics(monkeypatch):
-    # avoid users environment causing failures
-    monkeypatch.delitem(os.environ, 'prometheus_multiproc_dir', raising=False)
 
 
 class DummyTransport(raven.transport.Transport):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,8 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
-# make sure prometheus is setup in multiprocess mode. We don't actuall use this
-# dir in tests, as each test gets it's own directory, but this ensures
+# make sure prometheus is setup in multiprocess mode. We don't actually use
+# this dir in tests, as each test gets it's own directory, but this ensures
 # prometheus_client is imported in multiprocess mode
 from talisker import setup_multiproc_dir
 setup_multiproc_dir()

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -252,7 +252,11 @@ def test_statsd_metric(client, statsd_metrics):
     assert response.status_code == 200
 
 
-def test_metrics(client, prometheus_metrics):
+def test_metrics(client):
+    response = client.get('/_status/test/prometheus',
+                          environ_overrides={'REMOTE_ADDR': b'127.0.0.1'})
+    assert response.status_code == 200
+
     response = client.get('/_status/metrics',
                           environ_overrides={'REMOTE_ADDR': b'1.2.3.4'})
     assert response.status_code == 403
@@ -274,14 +278,15 @@ def test_metrics_no_prometheus(client, monkeypatch):
     assert response.status_code == 501
 
 
-def test_prometheus_metric(client, prometheus_metrics):
+def test_prometheus_metric(client):
     response = client.get('/_status/test/prometheus',
                           environ_overrides={'REMOTE_ADDR': b'127.0.0.1'})
     assert response.status_code == 200
     response = client.get('/_status/metrics',
                           environ_overrides={'REMOTE_ADDR': b'127.0.0.1'})
     assert response.status_code == 200
-    assert b'# HELP test test\n# TYPE test counter\ntest 1.0' in response.data
+    assert b'# HELP test Multiprocess metric\n' in response.data
+    assert b'# TYPE test counter\ntest 1.0' in response.data
 
 
 def test_info_packages(client):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -60,14 +60,14 @@ def test_histogram(statsd_metrics, registry):
 
     labels = {'label': 'value'}
     count = registry.get_metric('test_histogram_count', **labels)
-    sum = registry.get_metric('test_histogram_sum', **labels)
+    sum_ = registry.get_metric('test_histogram_sum', **labels)
     bucket = registry.get_metric('test_histogram_bucket', le='2.5', **labels)
 
     histogram.observe(2.0, **labels)
 
     assert statsd_metrics[0] == 'test.histogram.value:2.000000|ms'
     assert registry.get_metric('test_histogram_count', **labels) - count == 1.0
-    assert registry.get_metric('test_histogram_sum', **labels) - sum == 2.0
+    assert registry.get_metric('test_histogram_sum', **labels) - sum_ == 2.0
     after_bucket = registry.get_metric(
         'test_histogram_bucket', le='2.5', **labels)
     assert after_bucket - bucket == 1.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -74,7 +74,7 @@ def test_histogram(statsd_metrics, registry):
 
 
 def test_histogram_protected(log, registry):
-    histogram = talisker.metrics.Histogram(
+    histogram = metrics.Histogram(
         name='test_histogram_protected',
         documentation='test histogram',
         labelnames=['label'],
@@ -105,7 +105,7 @@ def test_counter(statsd_metrics, registry):
 
 
 def test_counter_protected(log, registry):
-    counter = talisker.metrics.Counter(
+    counter = metrics.Counter(
         name='test_counter_protected',
         documentation='test counter',
         labelnames=['label'],
@@ -115,7 +115,6 @@ def test_counter_protected(log, registry):
     counter.prometheus = 'THIS WILL RAISE'
     counter.inc(1, label='label')
     assert log[0].msg == 'Failed to increment counter metric'
-    assert registry.get_metric('test_counter', **labels) - count == 2
 
 
 def test_prometheus_cleanup(registry):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -29,44 +29,57 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
-from prometheus_client import REGISTRY
+import os
 
-import talisker.metrics
+import prometheus_client
+import pytest
 
-
-def get_metric(name, **labels):
-    value = REGISTRY.get_sample_value(name, labels)
-    return 0 if value is None else value
+from talisker import metrics
 
 
-def test_historgram(statsd_metrics):
-    histogram = talisker.metrics.Histogram(
+@pytest.fixture()
+def registry(monkeypatch, tmpdir):
+    registry = prometheus_client.CollectorRegistry()
+
+    def get_metric(name, **labels):
+        value = registry.get_sample_value(name, labels)
+        return 0 if value is None else value
+
+    registry.get_metric = get_metric
+    return registry
+
+
+def test_histogram(statsd_metrics, registry):
+    histogram = metrics.Histogram(
         name='test_histogram',
         documentation='test histogram',
         labelnames=['label'],
         statsd='{name}.{label}',
+        registry=registry,
     )
 
     labels = {'label': 'value'}
-    count = get_metric('test_histogram_count', **labels)
-    sum = get_metric('test_histogram_sum', **labels)
-    bucket = get_metric('test_histogram_bucket', le='2.5', **labels)
+    count = registry.get_metric('test_histogram_count', **labels)
+    sum = registry.get_metric('test_histogram_sum', **labels)
+    bucket = registry.get_metric('test_histogram_bucket', le='2.5', **labels)
 
     histogram.observe(2.0, **labels)
 
     assert statsd_metrics[0] == 'test.histogram.value:2.000000|ms'
-    assert get_metric('test_histogram_count', **labels) - count == 1.0
-    assert get_metric('test_histogram_sum', **labels) - sum == 2.0
-    after_bucket = get_metric('test_histogram_bucket', le='2.5', **labels)
+    assert registry.get_metric('test_histogram_count', **labels) - count == 1.0
+    assert registry.get_metric('test_histogram_sum', **labels) - sum == 2.0
+    after_bucket = registry.get_metric(
+        'test_histogram_bucket', le='2.5', **labels)
     assert after_bucket - bucket == 1.0
 
 
-def test_histogram_protected(log):
+def test_histogram_protected(log, registry):
     histogram = talisker.metrics.Histogram(
         name='test_histogram_protected',
         documentation='test histogram',
         labelnames=['label'],
         statsd='{name}.{label}',
+        registry=registry,
     )
 
     histogram.prometheus = 'THIS WILL RAISE'
@@ -74,23 +87,24 @@ def test_histogram_protected(log):
     assert log[0].msg == 'Failed to collect histogram metric'
 
 
-def test_counter(statsd_metrics):
-    counter = talisker.metrics.Counter(
+def test_counter(statsd_metrics, registry):
+    counter = metrics.Counter(
         name='test_counter',
         documentation='test counter',
         labelnames=['label'],
         statsd='{name}.{label}',
+        registry=registry,
     )
 
     labels = {'label': 'value'}
-    count = get_metric('test_counter', **labels)
+    count = registry.get_metric('test_counter', **labels)
     counter.inc(2, **labels)
 
     assert statsd_metrics[0] == 'test.counter.value:2|c'
-    assert get_metric('test_counter', **labels) - count == 2
+    assert registry.get_metric('test_counter', **labels) - count == 2
 
 
-def test_counter_protected(log):
+def test_counter_protected(log, registry):
     counter = talisker.metrics.Counter(
         name='test_counter_protected',
         documentation='test counter',
@@ -101,3 +115,101 @@ def test_counter_protected(log):
     counter.prometheus = 'THIS WILL RAISE'
     counter.inc(1, label='label')
     assert log[0].msg == 'Failed to increment counter metric'
+    assert registry.get_metric('test_counter', **labels) - count == 2
+
+
+def test_prometheus_cleanup(registry):
+    pid = 1
+
+    def getpid():
+        return pid
+
+    # override use of os.getpid. _ValueClass is recreated after every test,
+    # so we don't need to clean up
+    from prometheus_client import core
+    core._ValueClass = core._MultiProcessValue(getpid)
+
+    histogram = metrics.Histogram(
+        name='histogram',
+        documentation='test histogram',
+        labelnames=['label'],
+        statsd='{name}.{label}',
+        registry=registry,
+    )
+    counter = metrics.Counter(
+        name='counter',
+        documentation='test counter',
+        labelnames=['label'],
+        statsd='{name}.{label}',
+        registry=registry,
+    )
+
+    from prometheus_client.multiprocess import MultiProcessCollector
+    collector = MultiProcessCollector(registry)
+    labels = {'label': 'value'}
+
+    def collect():
+        return {m.name: m for m in collector.collect()}
+
+    def files():
+        return list(sorted(os.listdir(os.environ['prometheus_multiproc_dir'])))
+
+    counter.inc(1, **labels)
+    histogram.observe(0.5, **labels)
+    histogram.observe(2.5, **labels)
+
+    assert files() == [
+        'counter_1.db',
+        'histogram_1.db',
+    ]
+
+    before = collect()
+    metrics.prometheus_cleanup_worker(pid)
+    after = collect()
+    assert files() == [
+        'counter_archive.db',
+        'histogram_archive.db',
+    ]
+    assert before == after
+
+    # magic!
+    pid += 1
+
+    # new worker, create some new metrics, check they are all combined
+    counter.inc(2, **labels)
+    histogram.observe(0.5, **labels)
+    histogram.observe(2.5, **labels)
+
+    later = collect()
+    assert files() == [
+        'counter_2.db',
+        'counter_archive.db',
+        'histogram_2.db',
+        'histogram_archive.db',
+    ]
+
+    # check counter is correct
+    assert later['counter'].samples == [('counter', labels, 3.0)]
+
+    # check histogram is correct
+    later['histogram'].samples.sort(
+        key=lambda s: (s[0], float(s[1].get('le', 0))))
+    assert later['histogram'].samples == [
+        ('histogram_bucket', dict(le='0.005', **labels), 0.0),
+        ('histogram_bucket', dict(le='0.01', **labels), 0.0),
+        ('histogram_bucket', dict(le='0.025', **labels), 0.0),
+        ('histogram_bucket', dict(le='0.05', **labels), 0.0),
+        ('histogram_bucket', dict(le='0.075', **labels), 0.0),
+        ('histogram_bucket', dict(le='0.1', **labels), 0.0),
+        ('histogram_bucket', dict(le='0.25', **labels), 0.0),
+        ('histogram_bucket', dict(le='0.5', **labels), 2.0),
+        ('histogram_bucket', dict(le='0.75', **labels), 2.0),
+        ('histogram_bucket', dict(le='1.0', **labels), 2.0),
+        ('histogram_bucket', dict(le='2.5', **labels), 4.0),
+        ('histogram_bucket', dict(le='5.0', **labels), 4.0),
+        ('histogram_bucket', dict(le='7.5', **labels), 4.0),
+        ('histogram_bucket', dict(le='10.0', **labels), 4.0),
+        ('histogram_bucket', dict(le='+Inf', **labels), 4.0),
+        ('histogram_count', labels, 4.0),
+        ('histogram_sum', labels, 6.0),
+    ]


### PR DESCRIPTION
This should stop the leaking files and subsequent increasing scrape
response times.