### PR TITLE
statsd must be <3.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
     install_requires=[
         'gunicorn>=19.5.0,<20.0',
         'Werkzeug>=0.11.5,<0.15',
-        'statsd>=3.2.1,<4.0',
+        'statsd>=3.2.1,<3.3.0',
         'requests>=2.10.0,<3.0',
         'raven>=5.27.1,<7.0',
         'future>=0.15.2,<0.17',


### PR DESCRIPTION
Statsd v3.3.0 was released 23 hours ago: https://pypi.org/project/statsd/#history

This causes an error in Talisker:

``` python3
Traceback (most recent call last):
  File "/home/robin/git/www.ubuntu.com/env3/bin/talisker.gunicorn.gevent", line 11, in <module>
    sys.exit(run_gunicorn_gevent())
  File "/home/robin/git/www.ubuntu.com/env3/lib/python3.6/site-packages/talisker/__init__.py", line 198, in run_gunicorn_gevent
    run_gunicorn()
  File "/home/robin/git/www.ubuntu.com/env3/lib/python3.6/site-packages/talisker/__init__.py", line 171, in run_gunicorn
    config = initialise()
  File "/home/robin/git/www.ubuntu.com/env3/lib/python3.6/site-packages/talisker/__init__.py", line 53, in initialise
    import talisker.statsd
  File "/home/robin/git/www.ubuntu.com/env3/lib/python3.6/site-packages/talisker/statsd.py", line 32, in <module>
    from statsd.client import StatsClientBase, StatsClient
ImportError: cannot import name 'StatsClientBase'
```

The ideal solution would be to support statsd 3.3.0, but I don't immediately know how to do that. So for now I'm setting Talisker to require `<3.3.0`.