### PR TITLE
Properly serialize the prometheus worker cleanup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ packages = talisker
 test_suite = tests
 package_dir = talisker=talisker
 install_requires = 
-	gunicorn>=19.5.0,<20.0
+	gunicorn>=19.7.0,<20.0
 	Werkzeug>=0.11.5,<0.15
 	statsd>=3.2.1,<4.0
 	requests>=2.10.0,<3.0

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
     ),
     include_package_data=True,
     install_requires=[
-        'gunicorn>=19.5.0,<20.0',
+        'gunicorn>=19.7.0,<20.0',
         'Werkzeug>=0.11.5,<0.15',
         'statsd>=3.2.1,<4.0',
         'requests>=2.10.0,<3.0',

--- a/talisker/metrics.py
+++ b/talisker/metrics.py
@@ -41,8 +41,12 @@ import talisker.statsd
 
 try:
     import prometheus_client
+    from prometheus_client.multiprocess import mark_process_dead
 except ImportError:
     prometheus_client = False
+
+    def mark_process_dead(pid):
+        pass
 
 try:
     import statsd
@@ -149,45 +153,36 @@ def histogram_sorter(sample):
 
 
 def prometheus_cleanup_worker(pid):
-    """Clean up after a multiprocess worker has died."""
-    if not prometheus_client:
+    """Aggregate dead worker's metrics into a single archive file."""
+    mark_process_dead(pid)
+    prom_dir = os.environ['prometheus_multiproc_dir']
+    worker_files = [
+        'histogram_{}.db'.format(pid),
+        'counter_{}.db'.format(pid),
+    ]
+    paths = [os.path.join(prom_dir, f) for f in worker_files]
+    paths = [p for p in paths if os.path.exists(p)]
+
+    # check at least one worker file exists
+    if not paths:
         return
-    from prometheus_client.multiprocess import mark_process_dead
 
-    try:
-        mark_process_dead(pid)  # just deletes gauge files
-        prom_dir = os.environ['prometheus_multiproc_dir']
-        worker_files = [
-            'histogram_{}.db'.format(pid),
-            'counter_{}.db'.format(pid),
-        ]
-        paths = [os.path.join(prom_dir, f) for f in worker_files]
-        paths = [p for p in paths if os.path.exists(p)]
+    histogram_path = os.path.join(prom_dir, histogram_archive)
+    counter_path = os.path.join(prom_dir, counter_archive)
 
-        # check at least one worker file exists
-        if not paths:
-            return
+    metrics = collect(paths + [histogram_path, counter_path])
 
-        histogram_path = os.path.join(prom_dir, histogram_archive)
-        counter_path = os.path.join(prom_dir, counter_archive)
-        metrics = collect(paths + [histogram_path, counter_path])
+    tmp_histogram = tempfile.NamedTemporaryFile(delete=False)
+    tmp_counter = tempfile.NamedTemporaryFile(delete=False)
+    write_metrics(metrics, tmp_histogram.name, tmp_counter.name)
 
-        tmp_histogram = tempfile.NamedTemporaryFile(delete=False)
-        tmp_counter = tempfile.NamedTemporaryFile(delete=False)
-        write_metrics(metrics, tmp_histogram.name, tmp_counter.name)
+    # TODO: race condition window starts here
+    os.rename(tmp_histogram.name, histogram_path)
+    os.rename(tmp_counter.name, counter_path)
 
-        os.rename(tmp_histogram.name, histogram_path)
-        os.rename(tmp_counter.name, counter_path)
-
-        for path in paths:
-            os.unlink(path)
-
-    except Exception:
-        # we should never fail at cleaning up
-        logger.exception(
-            'failed to cleanup prometheus worker files',
-            extra={'caller': 'prometheus_cleanup_worker'},
-        )
+    for path in paths:
+        os.unlink(path)
+    # ends here
 
 
 def collect(files):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,7 @@
 #
 # Copyright (c) 2015-2018 Canonical, Ltd.
 #
-# This file is part of Talisker
-# (see http://github.com/canonical-ols/talisker).
+# This file is part of Talisker (see http://github.com/canonical-ols/talisker).
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -38,6 +37,7 @@ setup_multiproc_dir()
 # do this as early as possible, to set up logging in pytest
 import talisker.logs
 talisker.logs.configure_test_logging()
+talisker.logs.supress_noisy_logs()
 
 import ast
 import logging


### PR DESCRIPTION
The child_exit hook now just records the pid that needs cleaning, the
actual work is done in gunicorn's main loop, serialized and safe. To do
this we have to add a fake 'signal' to hook into gunicorns loop, but it
works.

In the process we also drop support for gunicorn <19.7, as they don't have a child_exit hook.