### PR TITLE
Support prometheus 0.4+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ lint: $(VENV)
 	$(BIN)/flake8 talisker tests
 
 _test: $(VENV)
-	. $(BIN)/activate && $(BIN)/pytest --tb=short -n auto $(ARGS)
+	. $(BIN)/activate && $(BIN)/pytest --timeout=15 $(ARGS)
 
 TEST_FILES = $(shell find tests -maxdepth 1 -name test_\*.py  | cut -c 7- | cut -d. -f1)
 $(TEST_FILES): $(VENV)

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ lint: $(VENV)
 	$(BIN)/flake8 talisker tests
 
 _test: $(VENV)
-	. $(BIN)/activate && $(BIN)/pytest --timeout=15 $(ARGS)
+	. $(BIN)/activate && $(BIN)/pytest -n auto --timeout=15 $(ARGS)
 
 TEST_FILES = $(shell find tests -maxdepth 1 -name test_\*.py  | cut -c 7- | cut -d. -f1)
 $(TEST_FILES): $(VENV)

--- a/requirements.tests.txt
+++ b/requirements.tests.txt
@@ -4,6 +4,7 @@ freezegun==0.3.10
 pytest-cov==2.5.1
 pytest-postgresql==1.3.4
 pytest-xdist==1.23.0
+pytest-timeout==1.3.2
 responses==0.9.0
 setuptools==40.4.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
 [options.extras_require]
 celery = celery>=3.1.13.0,<5.0
 django = django>=1.10,<2.0
-prometheus = prometheus-client>=0.2.0,<0.4.0
+prometheus = prometheus-client>=0.2.0,<0.5.0
 flask = 
 	flask>=0.11,<2.0
 	blinker>=1.4,<2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
 [options.extras_require]
 celery = celery>=3.1.13.0,<5.0
 django = django>=1.10,<2.0
-prometheus = prometheus-client>=0.2.0,<0.5.0
+prometheus = prometheus-client>=0.2.0,<0.5.0,!=0.4.0,!=0.4.1
 flask = 
 	flask>=0.11,<2.0
 	blinker>=1.4,<2.0

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(
             'psycopg2>=2.7.0,<3.0',
         ],
         prometheus=[
-            'prometheus-client>=0.2.0,<0.5.0',
+            'prometheus-client>=0.2.0,<0.5.0,!=0.4.0,!=0.4.1',
         ],
     ),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(
             'psycopg2>=2.7.0,<3.0',
         ],
         prometheus=[
-            'prometheus-client>=0.2.0,<0.4.0',
+            'prometheus-client>=0.2.0,<0.5.0',
         ],
     ),
     include_package_data=True,

--- a/talisker/metrics.py
+++ b/talisker/metrics.py
@@ -40,6 +40,7 @@ import time
 
 from talisker import prometheus_lock
 import talisker.statsd
+from talisker.util import pkg_version, TaliskerVersionException
 
 
 try:
@@ -48,6 +49,16 @@ try:
         MultiProcessCollector,
         mark_process_dead,
     )
+    prom_version = pkg_version('prometheus_client')
+    if prom_version in ('0.4.0', '0.4.1'):
+        raise TaliskerVersionException(
+            'prometheus_client {} has a critical bug in multiprocess mode, '
+            'and is not supported in Talisker. '
+            'https://github.com/prometheus/client_python/issues/322'.format(
+                prom_version,
+            )
+        )
+
 except ImportError:
     prometheus_client = False
 

--- a/talisker/util.py
+++ b/talisker/util.py
@@ -95,6 +95,10 @@ def pkg_is_installed(name):
         return False
 
 
+def pkg_version(name):
+    return pkg_resources.get_distribution(name).version
+
+
 class TaliskerVersionException(Exception):
     pass
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -42,6 +42,8 @@ import talisker.endpoints
 import talisker.revision
 from talisker.endpoints import StandardEndpointMiddleware
 
+from tests.test_metrics import counter_name
+
 
 @pytest.fixture
 def wsgi_app(status='200', headers=[], body=''):
@@ -283,8 +285,11 @@ def test_prometheus_metric(client):
     response = client.get('/_status/metrics',
                           environ_overrides={'REMOTE_ADDR': b'127.0.0.1'})
     assert response.status_code == 200
-    assert b'# HELP test Multiprocess metric\n' in response.data
-    assert b'# TYPE test counter\ntest 1.0' in response.data
+    output = response.data.decode('utf8')
+    name = counter_name('test_total')
+    assert '# HELP {} Multiprocess metric\n'.format(name) in output
+    assert '# TYPE {} counter'.format(name) in output
+    assert '{} 1.0'.format(name) in output
 
 
 def test_info_packages(client):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -100,7 +100,7 @@ def test_multiprocess_metrics(tmpdir):
     def get_count(response):
         for family in text_string_to_metric_families(response.text):
             if family.name == 'test':
-                return family.samples[0][-1]
+                return family.samples[0][2]
 
     # ensure we isolate multiprocess metrics
     env = os.environ.copy()

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skipsdist = True
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 usedevelop = True
 deps = -r{toxinidir}/requirements.tests.txt
-commands = py.test -n auto --cov=talisker
+commands = py.test --cov=talisker
 extras = 
     flask
     django

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skipsdist = True
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 usedevelop = True
 deps = -r{toxinidir}/requirements.tests.txt
-commands = py.test --cov=talisker
+commands = py.test -n auto --cov=talisker
 extras = 
     flask
     django


### PR DESCRIPTION
Prometheus 0.4+ has a number of changes that affect talisker's integration

1) there is now a merge method, which is good, as we added that, so we can use it :)
2) the format of samples changed from a 3-tuple to a 5-tuple
3) the name of the counter metric changed, it now adds '_total' on the end.

Hopefully we can drop support for prometheus_client <0.4 soonish, to avoid some of the abstraction added here.