### PR TITLE
Refactor sentry testing to maintain global client

### DIFF
--- a/talisker/django.py
+++ b/talisker/django.py
@@ -47,11 +47,10 @@ class SentryClient(DjangoClient):
     def __init__(self, *args, **kwargs):
         # SQL hook sends raw SQL to the server. Not cool, bro.
         kwargs['install_sql_hook'] = False
-        from_env = talisker.sentry.ensure_talisker_config(kwargs)
+        talisker.sentry.ensure_talisker_config(kwargs)
         logging.getLogger(__name__).info(
             'updating raven config from django app')
         super().__init__(*args, **kwargs)
-        talisker.sentry.log_client(self, from_env)
         # update any previously configured sentry client
         talisker.sentry.set_client(self)
 
@@ -59,6 +58,10 @@ class SentryClient(DjangoClient):
         data = super().build_msg(event_type, *args, **kwargs)
         talisker.sentry.add_talisker_context(data)
         return data
+
+    def set_dsn(self, dsn=None, transport=None):
+        super().set_dsn(dsn, transport)
+        talisker.sentry.log_client(self)
 
 
 def middleware(get_response):

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -181,7 +181,7 @@ def configure_warnings(enable):
         warnings.addHandler(logging.StreamHandler())
 
 
-def configure_test_logging():
+def configure_test_logging(handler=None):
     """Add a NullHandler to root logger.
 
     Prevents unconfigured logging from erroring, and swallows all logging,
@@ -189,7 +189,8 @@ def configure_test_logging():
     still add their own loggers to assert against log messages if needed.
     """
     set_logger_class()
-    handler = logging.FileHandler('/dev/null')
+    if handler is None:
+        handler = logging.NullHandler()
     add_talisker_handler(logging.NOTSET, handler)
     configure_warnings(True)
 

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -182,7 +182,7 @@ def configure_warnings(enable):
 
 
 def configure_test_logging(handler=None):
-    """Add a NullHandler to root logger.
+    """Add a handler (defaults to NullHandler) to root logger.
 
     Prevents unconfigured logging from erroring, and swallows all logging,
     which is usually what you want for unit tests.  Unit test fixtures can

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -120,6 +120,8 @@ def get_endpoint_name(endpoint):
 
 
 def get_session(cls=requests.Session):
+    if not hasattr(STORAGE, 'sessions'):
+        STORAGE.sessions = {}
     session = STORAGE.sessions.get(cls)
     if session is None:
         session = STORAGE.sessions[cls] = cls()

--- a/tests/django_app/django_app/settings.py
+++ b/tests/django_app/django_app/settings.py
@@ -1,9 +1,9 @@
 #
 # Copyright (c) 2015-2018 Canonical, Ltd.
-# 
+#
 # This file is part of Talisker
 # (see http://github.com/canonical-ols/talisker).
-# 
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -11,9 +11,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -66,6 +66,8 @@ INSTALLED_APPS = [
 ]
 
 SENTRY_CLIENT = 'talisker.django.SentryClient'
+SENTRY_TRANSPORT = 'talisker.testing.DummySentryTransport'
+SENTRY_DSN = 'https://user:pass@test.com/project'
 LOGGING_CONFIG = None
 CELERY_BROKER_URL = 'redis://localhost:6379/0'
 CELERY_ACCEPT_CONTENT = ['json']

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -31,7 +31,7 @@ from builtins import *  # noqa
 
 import talisker.django
 import talisker.sentry
-from talisker.testing import TEST_SENTRY_DSN
+from talisker.testing import DummySentryTransport, TEST_SENTRY_DSN
 
 
 def test_django_sentry_client(monkeypatch, context):
@@ -43,6 +43,7 @@ def test_django_sentry_client(monkeypatch, context):
     monkeypatch.setattr('raven.contrib.django.client.install_sql_hook', hook)
     client = talisker.django.SentryClient(
         dsn=TEST_SENTRY_DSN,
+        transport=DummySentryTransport,
         install_sql_hook=True,
     )
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -32,6 +32,7 @@ from builtins import *  # noqa
 import logging
 
 from flask import Flask
+import pytest
 
 import talisker.flask
 
@@ -46,19 +47,21 @@ class IgnoredException(Exception):
     pass
 
 
-app = Flask(__name__)
-app.config['SENTRY_TRANSPORT'] = DummySentryTransport
-app.config['SENTRY_DSN'] = TEST_SENTRY_DSN
+@pytest.fixture
+def flask_app():
+    app = Flask(__name__)
+    app.config['SENTRY_TRANSPORT'] = DummySentryTransport
+    app.config['SENTRY_DSN'] = TEST_SENTRY_DSN
 
+    @app.route('/')
+    def error():
+        raise Exception('app exception')
 
-@app.route('/')
-def error():
-    raise Exception('app exception')
+    @app.route('/ignored')
+    def ignored():
+        raise IgnoredException('test exception')
 
-
-@app.route('/ignored')
-def ignored():
-    raise IgnoredException('test exception')
+    return app
 
 
 def get_url(the_app, *args, **kwargs):
@@ -67,9 +70,9 @@ def get_url(the_app, *args, **kwargs):
         return app_client.get(*args, **kwargs)
 
 
-def test_flask_sentry_sends_message():
-    sentry = talisker.flask.sentry(app)
-    response = get_url(app, '/')
+def test_flask_sentry_sends_message(flask_app):
+    sentry = talisker.flask.sentry(flask_app)
+    response = get_url(flask_app, '/')
 
     assert response.status_code == 500
     msgs = get_sentry_messages(sentry.client)
@@ -81,31 +84,31 @@ def test_flask_sentry_sends_message():
         assert msg['transaction'] == '/'
 
 
-def test_flask_sentry_default_include_paths():
-    sentry = talisker.flask.sentry(app)
+def test_flask_sentry_default_include_paths(flask_app):
+    sentry = talisker.flask.sentry(flask_app)
     assert sentry.client.include_paths == set(['tests.test_flask'])
 
 
-def test_flask_sentry_uses_app_config_to_ingnore_exc(monkeypatch, context):
-    monkeypatch.setitem(app.config, 'SENTRY_CONFIG', {
+def test_flask_sentry_app_config_ignore_exc(flask_app, monkeypatch, context):
+    monkeypatch.setitem(flask_app.config, 'SENTRY_CONFIG', {
         'ignore_exceptions': ['IgnoredException']
     })
-    sentry = talisker.flask.sentry(app)
+    sentry = talisker.flask.sentry(flask_app)
 
     assert 'IgnoredException' in sentry.client.ignore_exceptions
 
-    response = get_url(app, '/ignored')
+    response = get_url(flask_app, '/ignored')
 
     assert response.status_code == 500
     assert len(get_sentry_messages(sentry.client)) == 0
 
 
-def test_flask_sentry_uses_app_config_to_set_name(monkeypatch):
-    monkeypatch.setitem(app.config, 'SENTRY_NAME', 'SomeName')
-    sentry = talisker.flask.sentry(app)
+def test_flask_sentry_uses_app_config_to_set_name(flask_app, monkeypatch):
+    monkeypatch.setitem(flask_app.config, 'SENTRY_NAME', 'SomeName')
+    sentry = talisker.flask.sentry(flask_app)
     assert sentry.client.name == 'SomeName'
 
-    response = get_url(app, '/')
+    response = get_url(flask_app, '/')
 
     assert response.status_code == 500
     msgs = get_sentry_messages(sentry.client)
@@ -114,82 +117,82 @@ def test_flask_sentry_uses_app_config_to_set_name(monkeypatch):
     assert msg['server_name'] == 'SomeName'
 
 
-def test_flask_sentry_app_tag():
-    sentry = talisker.flask.sentry(app)
-    response = get_url(app, '/')
+def test_flask_sentry_app_tag(flask_app):
+    sentry = talisker.flask.sentry(flask_app)
+    response = get_url(flask_app, '/')
 
     assert response.status_code == 500
     msgs = get_sentry_messages(sentry.client)
-    assert msgs[0]['tags']['flask_app'] == app.name
+    assert msgs[0]['tags']['flask_app'] == flask_app.name
 
 
 def test_flask_sentry_not_clear_afer_request(monkeypatch):
-    tapp = Flask(__name__)
+    app = Flask(__name__)
 
-    @tapp.route('/')
+    @app.route('/')
     def index():
         return 'ok'
 
-    sentry = talisker.flask.sentry(tapp)
+    sentry = talisker.flask.sentry(app)
     calls = []
     monkeypatch.setattr(sentry.client.context, 'clear',
                         lambda: calls.append(1))
-    get_url(tapp, '/')
+    get_url(app, '/')
     assert len(calls) == 0
     assert isinstance(sentry, talisker.flask.FlaskSentry)
 
 
 def test_talisker_flask_app():
-    tapp = talisker.flask.TaliskerApp(__name__)
+    app = talisker.flask.TaliskerApp(__name__)
     logname = getattr(app, 'logger_name', 'flask.app')
 
-    assert 'sentry' in tapp.extensions
-    assert tapp.logger is logging.getLogger(logname)
+    assert 'sentry' in app.extensions
+    assert app.logger is logging.getLogger(logname)
 
-    if 'LOGGER_HANDLER_POLICY' in tapp.config:
-        assert tapp.config['LOGGER_HANDLER_POLICY'] == 'never'
+    if 'LOGGER_HANDLER_POLICY' in app.config:
+        assert app.config['LOGGER_HANDLER_POLICY'] == 'never'
 
 
 def test_register_app():
-    tapp = Flask(__name__)
-    talisker.flask.register(tapp)
+    app = Flask(__name__)
+    talisker.flask.register(app)
 
     logname = getattr(app, 'logger_name', 'flask.app')
-    assert 'sentry' in tapp.extensions
-    assert tapp.logger is logging.getLogger(logname)
-    if 'LOGGER_HANDLER_POLICY' in tapp.config:
-        assert tapp.config['LOGGER_HANDLER_POLICY'] == 'never'
+    assert 'sentry' in app.extensions
+    assert app.logger is logging.getLogger(logname)
+    if 'LOGGER_HANDLER_POLICY' in app.config:
+        assert app.config['LOGGER_HANDLER_POLICY'] == 'never'
 
 
 def test_flask_view_name_header():
-    tapp = Flask(__name__)
+    app = Flask(__name__)
 
-    @tapp.route('/')
+    @app.route('/')
     def index():
         return 'ok'
 
-    talisker.flask.register(tapp)
-    response = get_url(tapp, '/')
+    talisker.flask.register(app)
+    response = get_url(app, '/')
     assert response.headers['X-View-Name'] == 'tests.test_flask.index'
 
 
 def test_flask_view_name_header_no_view(context):
-    tapp = Flask(__name__)
+    app = Flask(__name__)
 
-    @tapp.route('/')
+    @app.route('/')
     def index():
         return 'ok'
 
-    talisker.flask.register(tapp)
+    talisker.flask.register(app)
     context.logs[:] = []
-    response = get_url(tapp, '/notexist')
+    response = get_url(app, '/notexist')
     assert 'X-View-Name' not in response.headers
     assert context.logs.exists(msg="no flask view for /notexist")
 
 
 def test_flask_extension_updates_sentry_client():
     orig_client = talisker.sentry.get_client()
-    tapp = Flask(__name__)
-    ext = talisker.flask.sentry(tapp)
+    app = Flask(__name__)
+    ext = talisker.flask.sentry(app)
     assert ext.client is not orig_client
     assert talisker.sentry.get_client() is not orig_client

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -72,6 +72,8 @@ def test_log_record_list():
 
 def test_test_context():
 
+    assert testing.get_sentry_messages() == []
+
     logger = logging.getLogger('test_test_context')
     with testing.TestContext() as ctx:
         logger.info('foo', extra={'a': 1})
@@ -91,25 +93,9 @@ def test_test_context():
         name=logger.name, msg='bar', level='warning', extra={'b': 2})
 
     assert ctx.statsd == ['statsd:3.000000|ms']
-    assert len(ctx.sentry) == 1
-    assert ctx.sentry[0]['message'] == 'test'
-    # check that extra values have been decoded correctly
-    assert ctx.sentry[0]['extra']['foo'] == 'bar'
 
-
-def test_test_context_django(django):
-
-    with testing.TestContext() as ctx:
-        client = talisker.sentry.get_client()
-        assert isinstance(client, talisker.django.SentryClient)
-        talisker.sentry.get_client().capture(
-            'Message',
-            message='test',
-            extra={
-                'foo': 'bar'
-            },
-        )
-
+    # ensure there are not messages left over
+    assert testing.get_sentry_messages() == []
     assert len(ctx.sentry) == 1
     assert ctx.sentry[0]['message'] == 'test'
     # check that extra values have been decoded correctly


### PR DESCRIPTION
Rather that recreate the raven client on every test, instead change the
DSN/remote config for that test, and then restore.

This better supports raven's design, but involved slight refactor of the
logging of sentry set up

Also adds related testing setup helpers as part of the refactor.