### PR TITLE
Wsgi access logs

### DIFF
--- a/talisker/config.py
+++ b/talisker/config.py
@@ -32,6 +32,7 @@ from builtins import *  # noqa
 __metaclass__ = type
 
 import collections
+from future.utils import text_to_native_str
 from ipaddress import ip_network
 import os
 import subprocess
@@ -124,6 +125,7 @@ class Config():
         'TALISKER_SLOWQUERY_THRESHOLD': -1,
         'TALISKER_SOFT_REQUEST_TIMEOUT': -1,
         'TALISKER_NETWORKS': [],
+        'TALISKER_ID_HEADER': 'X-Request-Id',
     }
 
     Metadata = collections.namedtuple(
@@ -349,6 +351,15 @@ class Config():
         """
         tokens = self.raw.get(raw_name, '').split(',')
         return set(s for s in tokens if s.strip())
+
+    @config_property('TALISKER_ID_HEADER')
+    def id_header(self, raw_name):
+        """Header containing request id. Defaults to X-Request-Id."""
+        return text_to_native_str(self[raw_name])
+
+    @property
+    def wsgi_id_header(self):
+        return 'HTTP_' + self.id_header.upper().replace('-', '_')
 
 
 def parse_config_file(filename):

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -36,7 +36,6 @@ import threading
 import warnings
 
 from future.moves.urllib.parse import parse_qsl
-from future.utils import text_to_native_str
 import raven.breadcrumbs
 import requests
 import werkzeug.local
@@ -57,9 +56,6 @@ __all__ = [
     'get_session',
     'register_endpoint_name',
 ]
-
-# wsgi requires native strings
-HEADER = text_to_native_str(request_id.HEADER)
 
 STORAGE = threading.local()
 STORAGE.sessions = {}
@@ -150,11 +146,13 @@ def configure(session):
 
 def send_wrapper(func):
     """Sets header and records exception details."""
+    config = talisker.get_config()
+
     @functools.wraps(func)
     def send(request, **kwargs):
         rid = request_id.get()
-        if rid and HEADER not in request.headers:
-            request.headers[HEADER] = rid
+        if rid and config.id_header not in request.headers:
+            request.headers[config.id_header] = rid
         try:
             return func(request, **kwargs)
         except Exception as e:

--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -269,8 +269,7 @@ class TaliskerSentryMiddleware(ProxyClientMixin, raven.middleware.Sentry):
         super().__init__(application, get_client())
 
     def __call__(self, environ, start_response):
-        start_time = time.time()
-        environ['start_time'] = start_time
+        start_time = environ.setdefault('start_time', time.time())
         self.client.extra_context({'start_time': start_time})
         soft_start_timeout = talisker.get_config().soft_request_timeout
         if soft_start_timeout >= 0:

--- a/talisker/util.py
+++ b/talisker/util.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 __metaclass__ = type
 
+from collections import OrderedDict
 import errno
 import functools
 import logging

--- a/talisker/util.py
+++ b/talisker/util.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 __metaclass__ = type
 
-from collections import OrderedDict
 import errno
 import functools
 import logging

--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -28,63 +28,388 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import *  # noqa
+__metaclass__ = type
 
-import talisker.request_id
+from collections import OrderedDict
+import logging
+import os
+import time
+import traceback
+import sys
+
 import talisker.context
 import talisker.endpoints
-import talisker.statsd
 import talisker.requests
+import talisker.request_id
 import talisker.sentry
+import talisker.statsd
 from talisker.util import set_wsgi_header
 
 
+logger = logging.getLogger('talisker.wsgi')
+
 __all__ = [
-    'set_environ',
-    'set_headers',
-    'wrap'
+    'HEADER',
+    'wrap',
 ]
 
 
-def set_environ(app, **kwargs):
-    def middleware(environ, start_response):
-        for key, value in kwargs.items():
-            environ[key] = value
-        return app(environ, start_response)
-    return middleware
+class WSGIMetric:
+    latency = talisker.metrics.Histogram(
+        name='wsgi_latency',
+        documentation='Duration of requests served by WSGI',
+        labelnames=['view', 'status', 'method'],
+        statsd='{name}.{view}.{method}.{status}',
+        buckets=[4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192],
+    )
+
+    count = talisker.metrics.Counter(
+        name='wsgi_count',
+        documentation='Count of gunicorn requests',
+        labelnames=['view', 'status', 'method'],
+        statsd='{name}.{view}.{method}.{status}',
+    )
+
+    errors = talisker.metrics.Counter(
+        name='wsgi_errors',
+        documentation='Count of WSGI errors',
+        labelnames=['view', 'status', 'method'],
+        statsd='{name}.{view}.{method}.{status}',
+    )
 
 
-def set_headers(app, add_headers):
-    """Adds headers to response, overwriting any existing values."""
-    def middleware(environ, start_response):
-        def custom_start_response(status, response_headers, exc_info=None):
-            for header, value in add_headers.items():
-                set_wsgi_header(response_headers, header, value)
-            return start_response(status, response_headers, exc_info)
-        return app(environ, custom_start_response)
-    return middleware
+class WSGIResponse(object):
+    """Container for WSGI request/response cycle.
+
+    It adds some headers to the response, and captures the status, headers and
+    content length for obervability.
+    """
+
+    def __init__(self, environ, start_response, added_headers=None):
+        self.environ = environ
+        self.original_start_response = start_response
+        self.added_headers = added_headers
+
+        # response metadata
+        self.status = None
+        self.headers = None
+        self.exc_info = None
+        self.iter = None
+        self.status_code = 0
+        self.content_length = 0
+        self.file_path = None
+        self.closed = False
+        self.start_response_called = False
+
+    def start_response(self, status, headers, exc_info=None):
+        """Adds response headers and stores response data.
+
+        Does not directly call upstream start_response - that is done upon
+        iteration, to provide more control over status/headers in the case of
+        an error.
+        """
+        if self.added_headers:
+            for header, value in self.added_headers.items():
+                set_wsgi_header(headers, header, value)
+
+        if 'REQUEST_ID' in self.environ:
+            # set id header on outgoing response
+            config = talisker.get_config()
+            set_wsgi_header(
+                headers,
+                config.id_header,
+                self.environ['REQUEST_ID'],
+            )
+
+        self.status = status
+        status_code, _, _ = status.partition(' ')
+        self.status_code = int(status_code)
+        self.headers = headers
+        self.exc_info = exc_info
+
+    def ensure_start_response(self):
+        if not self.start_response_called:
+            self.original_start_response(
+                self.status,
+                self.headers,
+                self.exc_info,
+            )
+            self.start_response_called = True
+
+    def wrap(self, response_iter):
+        """Transforms this instance into an iterator that wraps the response.
+
+        Allows for error handling and tracking response size.
+        """
+        wrapper = self.environ.get('wsgi.file_wrapper')
+        if wrapper and isinstance(response_iter, wrapper):
+            # attempt to gather some metadata about the file for logging
+            filelike = getattr(response_iter, 'filelike', None)
+            if filelike:
+                self.file_path = getattr(filelike, 'name', None)
+                try:
+                    self.content_length = os.fstat(filelike.fileno()).st_size
+                except Exception:
+                    pass
+
+            # we can not wrap this, or we break sendfile optimisations in the
+            # server. But we do want to log it, so we patch its close method.
+            original_close = getattr(response_iter, 'close', lambda: None)
+
+            def close():
+                original_close()
+                self.log()
+            response_iter.close = close
+
+            # because we are not wrapping, we need to call start response now
+            self.ensure_start_response()
+
+            return response_iter
+        else:
+            self.iter = iter(response_iter)
+            return self
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """Wraps the provided WSGI content iterator.
+
+        It counts the bytes returned, as well attempting to handle any errors
+        thrown by the iterator.
+
+        """
+        if self.iter is None:
+            raise Exception("WSGIResponse: iterator has not been set yet")
+        # We don't actually call the provided start_response until we start
+        # iterating the content. This provides us with more control over the
+        # response, and allows us to more cleanly switch to an error response
+        # regardless of WSGI server implementation. Talisker apps can call
+        # start_response multiple times, and only the final call will influence
+        # the response status and headers. In Gunicorn for example, the headers
+        # from all calls to start_response would be sent, which usually not
+        # correct, and leads to duplictation or conflict of headers
+        self.ensure_start_response()
+        try:
+            chunk = next(self.iter)
+        except (StopIteration, GeneratorExit):
+            # not all middleware calls close, so ensure it's called.
+            # Note: this does slightly affect the measured response latency,
+            # which will not include time spent closing the client socket
+            self.close()
+            raise
+        except Exception:
+            # switch to generating an error response
+            self.iter = iter(self.error(sys.exc_info()))
+            chunk = next(self.iter)
+
+        self.content_length += len(chunk)
+        return chunk
+
+    def error(self, exc_info):
+        """Generate a WSGI response describing the error."""
+        # TODO: make this better, including json errors
+        self.start_response(
+            '500 Internal Server Error',
+            [('Content-Type', 'text/plain')],
+            exc_info,
+        )
+        # Note: the original start_response should raise if headers have been
+        # sent, which should bubble up to the WSGI server.
+        self.original_start_response(
+            self.status,
+            self.headers,
+            self.exc_info,
+        )
+
+        if talisker.get_config().devel:
+            lines = traceback.format_exception(*exc_info)
+            return [''.join(lines).encode('utf8')]
+        else:
+            return [exc_info[0].__name__.encode('utf8')]
+
+    def close(self):
+        """Close and record the response."""
+        if self.closed:
+            return
+
+        try:
+            iter_close = getattr(self.iter, 'close', None)
+            if iter_close:
+                iter_close()
+        finally:
+            self.log()
+            self.closed = True
+
+    def log(self):
+        duration = time.time() - self.environ['start_time']
+        log_response(
+            self.environ,
+            self.status_code,
+            self.headers,
+            duration,
+            self.content_length,
+            exc_info=self.exc_info,
+            filepath=self.file_path,
+        )
+
+
+class TaliskerMiddleware():
+    """Talisker entrypoint for WSGI apps.
+
+    Sets up some values in environ, handles errors, and wraps responses in
+    WSGIResponse.
+    """
+    def __init__(self, app, environ=None, headers=None):
+
+        """Configure talisker middleware.
+
+         - app: the wsgi app
+         - environ: things to put in the environment
+         - headers: additional headers to to add
+        """
+        self.app = app
+        self.environ = environ
+        self.headers = headers
+
+    def __call__(self, environ, start_response):
+        start_time = time.time()
+        environ['start_time'] = start_time
+        config = talisker.get_config()
+
+        # ensure request id
+        if config.wsgi_id_header not in environ:
+            environ[config.wsgi_id_header] = talisker.request_id.generate()
+        rid = environ[config.wsgi_id_header]
+        talisker.request_id.push(rid)
+
+        # setup environment
+        environ['REQUEST_ID'] = rid
+        if self.environ:
+            for key, value in self.environ.items():
+                environ[key] = value
+
+        response = WSGIResponse(environ, start_response, self.headers)
+
+        try:
+            response_iter = self.app(environ, response.start_response)
+        except Exception:
+            response_iter = response.error(sys.exc_info())
+
+        return response.wrap(response_iter)
+
+
+def get_metadata(environ,
+                 status,
+                 headers,
+                 duration,
+                 length,
+                 exc_info=None,
+                 trailer=True,
+                 filepath=None):
+    """Return an ordered dictionary of request metadata for logging."""
+    headers = dict((k.lower(), v) for k, v in headers)
+    extra = OrderedDict()
+    extra['method'] = environ.get('REQUEST_METHOD')
+    extra['path'] = environ.get('PATH_INFO')
+    qs = environ.get('QUERY_STRING')
+    if qs:
+        extra['qs'] = environ.get('QUERY_STRING')
+    extra['status'] = status
+    if 'x-view-name' in headers:
+        extra['view'] = headers['x-view-name']
+    extra['duration_ms'] = round(duration * 1000, 3)
+    extra['ip'] = environ.get('REMOTE_ADDR', None)
+    extra['proto'] = environ.get('SERVER_PROTOCOL')
+    extra['length'] = length
+    if filepath is not None:
+        extra['filepath'] = filepath
+    if 'CONTENT_LENGTH' in environ:
+        try:
+            extra['request_length'] = int(environ['CONTENT_LENGTH'])
+        except ValueError:
+            pass
+    if 'CONTENT_TYPE' in environ:
+        extra['request_type'] = environ['CONTENT_TYPE']
+    referrer = environ.get('HTTP_REFERER', None)
+    if referrer is not None:
+        extra['referrer'] = environ.get('HTTP_REFERER', None)
+    if 'HTTP_X_FORWARDED_FOR' in environ:
+        extra['forwarded'] = environ['HTTP_X_FORWARDED_FOR']
+    if 'HTTP_USER_AGENT' in environ:
+        extra['ua'] = environ['HTTP_USER_AGENT']
+
+    if exc_info and exc_info[0]:
+        extra['exc_type'] = str(exc_info[0].__name__)
+        if trailer:
+            extra['trailer'] = ''.join(
+                traceback.format_exception(*exc_info)
+            )
+
+    tracking = getattr(talisker.context.CONTEXT, 'request_tracking', {})
+    for name, tracker in tracking.items():
+        extra[name + '_count'] = tracker.count
+        extra[name + '_time_ms'] = tracker.time
+
+    msg = "{method} {path}{0}".format('?' if 'qs' in extra else '', **extra)
+    return msg, extra
+
+
+def log_response(environ,
+                 status,
+                 headers,
+                 duration,
+                 length,
+                 exc_info=None,
+                 trailer=True,
+                 filepath=None):
+    """Log a WSGI request and record metrics.
+
+    Similar to access logs, but structured and with more data."""
+    try:
+        msg, extra = get_metadata(
+            environ,
+            status,
+            headers,
+            duration,
+            length,
+            exc_info,
+            trailer,
+            filepath,
+        )
+        logger.info(msg, extra=extra)
+    except Exception:
+        logger.exception('error generating access log')
+    else:
+        labels = {
+            'view': extra.get('view', 'unknown'),
+            'method': extra['method'],
+            'status': str(status),
+        }
+
+        WSGIMetric.count.inc(**labels)
+        WSGIMetric.latency.observe(extra['duration_ms'], **labels)
+        if status >= 500:
+            WSGIMetric.errors.inc(**labels)
 
 
 def wrap(app):
+    """Wraps a WSGI api in Talisker middleware."""
     if getattr(app, '_talisker_wrapped', False):
         return app
 
     config = talisker.config.get_config()
+    environ = {
+        'statsd': talisker.statsd.get_client(),
+        'requests': talisker.requests.get_session(),
+    }
+    headers = {'X-VCS-Revision': config.revision_id}
 
     wrapped = app
     # added in reverse order
-    wrapped = set_headers(
-        wrapped, {'X-VCS-Revision': config.revision_id})
-    # expose some standard endpoint
     wrapped = talisker.endpoints.StandardEndpointMiddleware(wrapped)
-    # set some standard environ items
-    wrapped = set_environ(
-        wrapped,
-        statsd=talisker.statsd.get_client(),
-        requests=talisker.requests.get_session(),
-    )
-    # add request id info to thread locals
-    wrapped = talisker.request_id.RequestIdMiddleware(wrapped)
     wrapped = talisker.sentry.TaliskerSentryMiddleware(wrapped)
+    wrapped = TaliskerMiddleware(wrapped, environ, headers)
     wrapped._talisker_wrapped = True
     wrapped._talisker_original_app = app
     return wrapped

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -29,8 +29,14 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
-from talisker.testing import run_wsgi
-from talisker import wsgi
+import time
+import wsgiref.util
+
+import pytest
+from freezegun import freeze_time
+
+from talisker import request_id, wsgi
+from talisker.context import track_request_metric
 
 
 def app(environ, start_response):
@@ -38,29 +44,466 @@ def app(environ, start_response):
     return environ
 
 
-def test_set_environ(wsgi_env):
-    stack = wsgi.set_environ(app, X=1)
-    env, status, headers = run_wsgi(stack, wsgi_env)
-    assert env['X'] == 1
+def create_environ(environ, url):
+    """Helper to creater a test WSGI environ."""
+    parts = url.split('?')
+    path = parts[0]
+    qs = parts[1] if len(parts) > 1 else ''
+    environ['RAW_URI'] = url
+    if qs:
+        environ['QUERY_STRING'] = qs
+    environ['PATH_INFO'] = path
+    environ['REMOTE_ADDR'] = '127.0.0.1'
+    return environ
 
 
-def test_set_headers(wsgi_env):
-    stack = wsgi.set_headers(app, {'extra': 'header'})
-    env, status, headers = run_wsgi(stack, wsgi_env)
-    assert ('extra', 'header') in headers
+@pytest.fixture
+def start_response():
+    def mock_start_response(status, headers, exc_info=None):
+        mock_start_response.status = status
+        mock_start_response.exc_info = exc_info
+        # gunicorn does this for multiple calls to start_response, but doesn't
+        # actually sent them till the body is iterated
+        mock_start_response.headers = headers
+        mock_start_response.body = body = []
+
+        # this mimics expected WSGI server behaviour
+        if exc_info and mock_start_response.headers_sent:
+            raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
+        return lambda x: body.append(x)
+
+    mock_start_response.headers_sent = False
+
+    return mock_start_response
 
 
-def test_set_headers_overwrites(wsgi_env):
-    def proxy(environ, start_response):
-        start_response(200, [('extra', 'foo')])
-        return 'ok'
-    stack = wsgi.set_headers(app, {'extra': 'header'})
-    env, status, headers = run_wsgi(stack, wsgi_env)
-    assert ('extra', 'header') in headers
-    assert ('extra', 'foo') not in headers
+def test_wsgi_response_start_response(wsgi_env, start_response):
+    wsgi_env['REQUEST_ID'] = 'ID'
+    environ = create_environ(wsgi_env, '/')
+    headers = {'HEADER': 'VALUE'}
+    response = wsgi.WSGIResponse(environ, start_response, headers)
+    response.start_response('200 OK', [], None)
+    response.ensure_start_response()
+    assert response.status_code == 200
+    assert start_response.status == response.status == '200 OK'
+    assert start_response.headers == response.headers == [
+        ('HEADER', 'VALUE'),
+        ('X-Request-Id', 'ID'),
+    ]
+    assert start_response.exc_info is response.exc_info is None
 
 
-def test_wrapping():
+@freeze_time('2016-01-02 03:04:05.1234')
+def test_wsgi_response_wrap(wsgi_env, start_response, context):
+    environ = create_environ(wsgi_env, '/')
+    environ['start_time'] = time.time() - 1.0
+    response = wsgi.WSGIResponse(environ, start_response)
+    response.start_response('200 OK', [], None)
+    output = b''.join(response.wrap([b'output', b' ', b'here']))
+
+    assert output == b'output here'
+    context.assert_log(
+        msg='GET /',
+        extra=dict([
+            ('method', 'GET'),
+            ('path', '/'),
+            ('status', 200),
+            ('duration_ms', 1000.0),
+            ('ip', '127.0.0.1'),
+            ('proto', 'HTTP/1.0'),
+            ('length', len(output)),
+        ]),
+    )
+
+
+@freeze_time('2016-01-02 03:04:05.1234')
+def test_wsgi_response_wrap_file(wsgi_env, start_response, context, tmpdir):
+    path = tmpdir.join('filecontent')
+    path.write('CONTENT')
+    environ = create_environ(wsgi_env, '/')
+    environ['start_time'] = time.time() - 1.0
+    environ['wsgi.file_wrapper'] = wsgiref.util.FileWrapper
+
+    response = wsgi.WSGIResponse(environ, start_response)
+    response.start_response('200 OK', [], None)
+    wrapper = wsgiref.util.FileWrapper(open(str(path)))
+    respiter = response.wrap(wrapper)
+    output = ''.join(respiter)
+    respiter.close()
+
+    assert output == 'CONTENT'
+    context.assert_log(
+        msg='GET /',
+        extra=dict([
+            ('method', 'GET'),
+            ('path', '/'),
+            ('status', 200),
+            ('duration_ms', 1000.0),
+            ('ip', '127.0.0.1'),
+            ('proto', 'HTTP/1.0'),
+            ('length', len(output)),
+            ('filepath', str(path)),
+        ]),
+    )
+
+
+@freeze_time('2016-01-02 03:04:05.1234')
+def test_wsgi_response_wrap_error(wsgi_env, start_response, context):
+    environ = create_environ(wsgi_env, '/')
+    environ['start_time'] = time.time() - 1.0
+    response = wsgi.WSGIResponse(environ, start_response)
+    response.start_response('200 OK', [], None)
+
+    class ErrorGenerator():
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise Exception('error')
+
+    output = b''.join(response.wrap(ErrorGenerator()))
+
+    assert output == b'Exception'
+
+    context.assert_log(
+        msg='GET /',
+        extra=dict([
+            ('method', 'GET'),
+            ('path', '/'),
+            ('status', 500),
+            ('duration_ms', 1000.0),
+            ('ip', '127.0.0.1'),
+            ('proto', 'HTTP/1.0'),
+            ('length', len(output)),
+            ('exc_type', 'Exception'),
+        ]),
+    )
+
+
+@freeze_time('2016-01-02 03:04:05.1234')
+def test_wsgi_response_wrap_error_headers_sent(
+        wsgi_env, start_response, context):
+    environ = create_environ(wsgi_env, '/')
+    environ['start_time'] = time.time() - 1.0
+    response = wsgi.WSGIResponse(environ, start_response)
+    response.start_response('200 OK', [], None)
+
+    def iterator():
+        start_response.headers_sent = True
+        yield b'some content'
+        raise Exception('error')
+
+    it = response.wrap(iterator())
+    with pytest.raises(Exception):
+        list(it)
+
+
+def test_middleware_basic(wsgi_env, start_response, context):
+
+    def app(environ, _start_response):
+        _start_response('200 OK', [('Content-Type', 'text/plain')])
+        return [b'OK']
+
+    extra_env = {'ENV': 'VALUE'}
+    extra_headers = {'Some-Header': 'value'}
+    wsgi_env['HTTP_X_REQUEST_ID'] = 'ID'
+
+    mw = wsgi.TaliskerMiddleware(app, extra_env, extra_headers)
+    output = b''.join(mw(wsgi_env, start_response))
+
+    assert output == b'OK'
+    assert wsgi_env['ENV'] == 'VALUE'
+    assert wsgi_env['REQUEST_ID'] == 'ID'
+    assert start_response.status == '200 OK'
+    assert start_response.headers == [
+        ('Content-Type', 'text/plain'),
+        ('Some-Header', 'value'),
+        ('X-Request-Id', 'ID'),
+    ]
+
+    context.assert_log(name='talisker.wsgi', msg='GET /')
+
+
+def test_middleware_error_before_start_response(
+        wsgi_env, start_response, context):
+
+    def app(environ, _start_response):
+        raise Exception('error')
+
+    extra_env = {'ENV': 'VALUE'}
+    extra_headers = {'Some-Header': 'value'}
+    wsgi_env['HTTP_X_REQUEST_ID'] = 'ID'
+
+    mw = wsgi.TaliskerMiddleware(app, extra_env, extra_headers)
+    output = b''.join(mw(wsgi_env, start_response))
+
+    assert output == b'Exception'
+    assert wsgi_env['ENV'] == 'VALUE'
+    assert wsgi_env['REQUEST_ID'] == 'ID'
+    assert start_response.status == '500 Internal Server Error'
+    assert start_response.headers == [
+        ('Content-Type', 'text/plain'),
+        ('Some-Header', 'value'),
+        ('X-Request-Id', 'ID'),
+    ]
+    assert start_response.exc_info[0] is Exception
+
+    context.assert_log(
+        name='talisker.wsgi',
+        msg='GET /',
+        extra={
+            'status': 500,
+            'exc_type': 'Exception',
+        },
+    )
+
+
+def test_middleware_error_after_start_response(
+        wsgi_env, start_response, context):
+
+    def app(environ, _start_response):
+        _start_response('200 OK', [('Content-Type', 'application/json')])
+        raise Exception('error')
+
+    extra_env = {'ENV': 'VALUE'}
+    extra_headers = {'Some-Header': 'value'}
+    wsgi_env['HTTP_X_REQUEST_ID'] = 'ID'
+
+    mw = wsgi.TaliskerMiddleware(app, extra_env, extra_headers)
+    output = b''.join(mw(wsgi_env, start_response))
+
+    assert output == b'Exception'
+    assert wsgi_env['ENV'] == 'VALUE'
+    assert wsgi_env['REQUEST_ID'] == 'ID'
+    assert start_response.status == '500 Internal Server Error'
+    assert start_response.headers == [
+        ('Content-Type', 'text/plain'),
+        ('Some-Header', 'value'),
+        ('X-Request-Id', 'ID'),
+    ]
+
+    context.assert_log(
+        name='talisker.wsgi',
+        msg='GET /',
+        extra={
+            'status': 500,
+            'exc_type': 'Exception',
+        },
+    )
+
+
+def test_get_metadata_basic(wsgi_env):
+    environ = create_environ(wsgi_env, '/')
+    msg, extra = wsgi.get_metadata(
+        environ,
+        status=200,
+        headers=[],
+        duration=1,
+        length=1000,
+    )
+    assert msg == 'GET /'
+    assert list(extra.items()) == [
+        ('method', 'GET'),
+        ('path', '/'),
+        ('status', 200),
+        ('duration_ms', 1000.0),
+        ('ip', '127.0.0.1'),
+        ('proto', 'HTTP/1.0'),
+        ('length', 1000),
+    ]
+
+
+def test_get_metadata_query_string(wsgi_env):
+    environ = create_environ(wsgi_env, '/foo?bar=baz')
+    msg, extra = wsgi.get_metadata(
+        environ,
+        status=200,
+        headers=[],
+        duration=1,
+        length=1000,
+    )
+    assert msg == 'GET /foo?'
+    assert list(extra.items()) == [
+        ('method', 'GET'),
+        ('path', '/foo'),
+        ('qs', 'bar=baz'),
+        ('status', 200),
+        ('duration_ms', 1000.0),
+        ('ip', '127.0.0.1'),
+        ('proto', 'HTTP/1.0'),
+        ('length', 1000),
+    ]
+
+
+def test_get_metadata_view(wsgi_env):
+    environ = create_environ(wsgi_env, '/')
+    msg, extra = wsgi.get_metadata(
+        environ,
+        status=200,
+        headers=[('X-View-Name', 'view')],
+        duration=1,
+        length=1000,
+    )
+    assert extra['view'] == 'view'
+
+
+def test_get_metadata_forwarded(wsgi_env):
+    wsgi_env['HTTP_X_FORWARDED_FOR'] = '203.0.113.195, 150.172.238.178'
+    environ = create_environ(wsgi_env, '/')
+    msg, extra = wsgi.get_metadata(
+        environ,
+        status=200,
+        headers=[],
+        duration=1,
+        length=1000,
+    )
+    assert extra['forwarded'] == '203.0.113.195, 150.172.238.178'
+
+
+def test_get_metadata_request_body(wsgi_env):
+    wsgi_env['CONTENT_LENGTH'] = '100'
+    wsgi_env['CONTENT_TYPE'] = 'application/json'
+    environ = create_environ(wsgi_env, '/')
+    msg, extra = wsgi.get_metadata(
+        environ,
+        status=200,
+        headers=[],
+        duration=1,
+        length=1000,
+    )
+    assert extra['request_length'] == 100
+    assert extra['request_type'] == 'application/json'
+
+
+def test_get_metadata_referrer(wsgi_env):
+    wsgi_env['HTTP_REFERER'] = 'referrer'
+    environ = create_environ(wsgi_env, '/')
+    msg, extra = wsgi.get_metadata(
+        environ,
+        status=200,
+        headers=[],
+        duration=1,
+        length=1000,
+    )
+    assert extra['referrer'] == 'referrer'
+
+
+def test_get_metadata_ua(wsgi_env):
+    wsgi_env['HTTP_USER_AGENT'] = 'ua'
+    environ = create_environ(wsgi_env, '/')
+    msg, extra = wsgi.get_metadata(
+        environ,
+        status=200,
+        headers=[],
+        duration=1,
+        length=1000,
+    )
+    assert extra['ua'] == 'ua'
+
+
+def test_get_metadata_tracking(wsgi_env):
+    track_request_metric('sql', 1.0)
+    track_request_metric('http', 2.0)
+    track_request_metric('log', 3.0)
+    environ = create_environ(wsgi_env, '/')
+    msg, extra = wsgi.get_metadata(
+        environ,
+        status=200,
+        headers=[],
+        duration=1,
+        length=1000,
+    )
+    assert extra['sql_count'] == 1
+    assert extra['sql_time_ms'] == 1.0
+    assert extra['http_count'] == 1
+    assert extra['http_time_ms'] == 2.0
+    assert extra['log_count'] == 1
+    assert extra['log_time_ms'] == 3.0
+
+
+def test_log_response(wsgi_env, context):
+    environ = create_environ(wsgi_env, '/')
+    with request_id.context('ID'):
+        wsgi.log_response(
+            environ,
+            status=200,
+            headers=[],
+            duration=1,
+            length=1000,
+        )
+
+    extra = dict([
+        ('method', 'GET'),
+        ('path', '/'),
+        ('status', 200),
+        ('duration_ms', 1000.0),
+        ('ip', '127.0.0.1'),
+        ('proto', 'HTTP/1.0'),
+        ('length', 1000),
+        ('request_id', 'ID'),
+    ])
+    context.assert_log(
+        name='talisker.wsgi',
+        msg='GET /',
+        extra=extra,
+    )
+
+
+def test_log_response_error(wsgi_env, context):
+    environ = create_environ(wsgi_env, '/')
+    wsgi.log_response(
+        environ,
+        status=500,
+        headers=[('X-View-Name', 'view')],
+        duration=1,
+        length=1000,
+    )
+    extra = dict([
+        ('method', 'GET'),
+        ('path', '/'),
+        ('status', 500),
+        ('duration_ms', 1000.0),
+        ('ip', '127.0.0.1'),
+        ('proto', 'HTTP/1.0'),
+        ('length', 1000),
+    ])
+    context.assert_log(
+        name='talisker.wsgi',
+        msg='GET /',
+        extra=extra,
+    )
+
+    assert context.statsd[0] == 'wsgi.count.view.GET.500:1|c'
+    assert context.statsd[1] == 'wsgi.latency.view.GET.500:1000.000000|ms'
+    assert context.statsd[2] == 'wsgi.errors.view.GET.500:1|c'
+
+
+def test_log_response_raises(wsgi_env, context, monkeypatch):
+
+    def error(*args, **kwargs):
+        raise Exception('error')
+
+    monkeypatch.setattr(wsgi, 'get_metadata', error)
+
+    environ = create_environ(wsgi_env, '/')
+    wsgi.log_response(
+        environ,
+        status=500,
+        headers=[('X-View-Name', 'view')],
+        duration=1,
+        length=1000,
+    )
+
+    context.assert_log(
+        name='talisker.wsgi',
+        level='error',
+        msg='error generating access log',
+    )
+
+    assert context.statsd == []
+
+
+def test_wrap():
     wrapped = wsgi.wrap(app)
 
     assert wrapped._talisker_wrapped is True


### PR DESCRIPTION
Move all access logging and metrics into the WSGI middleware, and out of gunicorn.

This makes us much more portable between wsgi servers. Additionally, if gives us much more explicit control of our error handling, which has been a goal for while.

Some parts of this are a little tricky, as WSGI is not conducive to some of what we are trying to do. We effectively take control of aspects of WSGI that are typically handled by a WSGI server.