### PR TITLE
Move the logic from the sentry WSGI middleware into Talisker's middleware

### DIFF
--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -291,56 +291,13 @@ def test_sql_summary_crumb():
     }
 
 
-def test_middleware_soft_request_timeout(config, wsgi_env, context):
-    config['TALISKER_SOFT_REQUEST_TIMEOUT'] = '0'
-
-    def app(environ, start_response):
-        start_response(200, [])
-        return []
-
-    mw = talisker.sentry.TaliskerSentryMiddleware(app)
-    body, _, _ = testing.run_wsgi(mw, wsgi_env)
-    list(body)
-    assert 'Start_response over timeout: 0' == context.sentry[0]['message']
-    assert 'warning' == context.sentry[0]['level']
-
-
-def test_middleware_soft_request_timeout_non_zero(config, wsgi_env, context):
-    config['TALISKER_SOFT_REQUEST_TIMEOUT'] = '100'
-
-    def app(environ, start_response):
-        time.sleep(200 / 1000.0)
-        start_response(200, [])
-        return []
-
-    mw = talisker.sentry.TaliskerSentryMiddleware(app)
-    body, _, _ = testing.run_wsgi(mw, wsgi_env)
-    list(body)
-    assert 'Start_response over timeout: 100' == context.sentry[0]['message']
-
-
-def test_middleware_soft_request_timeout_disabled_by_default(
-        wsgi_env, context):
-    def app(environ, start_response):
-        start_response(200, [])
-        return []
-
-    mw = talisker.sentry.TaliskerSentryMiddleware(app)
-    body, _, _ = testing.run_wsgi(mw, wsgi_env)
-    list(body)
-    assert len(context.sentry) == 0
-
-
 def test_proxy_mixin():
     client = talisker.sentry.get_client()
     lh = talisker.sentry.get_log_handler()
-    mw = talisker.sentry.TaliskerSentryMiddleware(lambda: None)
     assert lh.client is client
-    assert mw.client is client
     new_client = talisker.sentry.configure_client()
     assert talisker.sentry.get_client() is new_client
     assert lh.client is new_client
-    assert mw.client is new_client
 
 
 def test_logs_ignored():

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -74,6 +74,29 @@ def test_wsgi_response_start_response(wsgi_env, start_response):
     assert start_response.exc_info is response.exc_info is None
 
 
+def test_wsgi_response_soft_timeout_default(wsgi_env, start_response, context):
+    with freeze_time() as frozen:
+        wsgi_env['start_time'] = time.time()
+        response = wsgi.WSGIResponse(wsgi_env, start_response, [])
+        frozen.tick(100)
+        response.start_response('200 OK', [], None)
+
+    assert context.sentry == []
+
+
+def test_wsgi_response_soft_explicit(wsgi_env, start_response, context):
+    with freeze_time() as frozen:
+        wsgi_env['start_time'] = time.time()
+        response = wsgi.WSGIResponse(wsgi_env, start_response, [], 100)
+        frozen.tick(2.0)
+        response.start_response('200 OK', [], None)
+
+    assert (
+        context.sentry[0]['message'] == 'Start_response over timeout: 100ms'
+    )
+    assert context.sentry[0]['level'] == 'warning'
+
+
 @freeze_time('2016-01-02 03:04:05.1234')
 def test_wsgi_response_wrap(wsgi_env, start_response, context):
     wsgi_env['start_time'] = time.time() - 1.0
@@ -222,6 +245,7 @@ def test_middleware_error_before_start_response(
         ('Content-Type', 'text/plain'),
         ('Some-Header', 'value'),
         ('X-Request-Id', 'ID'),
+        ('X-Sentry-ID', wsgi_env['SENTRY_ID']),
     ]
     assert start_response.exc_info[0] is Exception
 
@@ -257,6 +281,7 @@ def test_middleware_error_after_start_response(
         ('Content-Type', 'text/plain'),
         ('Some-Header', 'value'),
         ('X-Request-Id', 'ID'),
+        ('X-Sentry-ID', wsgi_env['SENTRY_ID']),
     ]
 
     context.assert_log(


### PR DESCRIPTION
This means:
  - cleaner implementation and less overhead
  - X-Sentry-ID header always included if there was a sentry report
  - we now support the wsgi.file_wrapper optimisation, which the sentry
  middleware breaks.