### PR TITLE
Track in flight requests and log any when gunicorn workers exit

### DIFF
--- a/talisker/django.py
+++ b/talisker/django.py
@@ -69,6 +69,8 @@ def middleware(get_response):
     def add_view_name(request):
         response = get_response(request)
         if getattr(request, 'resolver_match', None):
-            response['X-View-Name'] = request.resolver_match.view_name
+            view_name = request.resolver_match.view_name
+            response['X-View-Name'] = view_name
+            request.environ['VIEW_NAME'] = view_name
         return response
     return add_view_name

--- a/talisker/flask.py
+++ b/talisker/flask.py
@@ -100,6 +100,7 @@ def add_view_name(response):
         ))
     else:
         response.headers['X-View-Name'] = name
+        flask.request.environ['VIEW_NAME'] = name
 
     return response
 

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -116,7 +116,7 @@ def gunicorn_child_exit(server, worker):
 def gunicorn_worker_exit(server, worker):
     """Logs any requests that are still in flight."""
     now = time.time()
-    for id, env in talisker.wsgi.REQUESTS.items():
+    for env in talisker.wsgi.REQUESTS.values():
         duration = now - env['start_time']
         talisker.wsgi.log_response(
             env,

--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -61,6 +61,10 @@ __all__ = [
     'wrap',
 ]
 
+# track in-flight requests for this worker process, allows use to still log
+# them in the case of timeouts and other issues
+REQUESTS = {}
+
 
 def talisker_error_response(environ, headers, exc_info):
     """Returns WSGI iterable to be returned as an error response
@@ -366,9 +370,10 @@ class WSGIResponse():
             except Exception:
                 logger.exception('failed to send soft timeout report')
 
-        self.sentry.context.clear()
-        self.sentry.transaction.clear()
-        # TODO: clear other contexts
+        talisker.clear_contexts()
+        rid = self.environ.get('REQUEST_ID')
+        if rid:
+            REQUESTS.pop(rid, None)
 
     def report_error(self):
         self.sentry.extra_context({'start_time': self.environ['start_time']})
@@ -412,6 +417,8 @@ class TaliskerMiddleware():
         environ['REQUEST_ID'] = rid
         talisker.request_id.push(rid)
 
+        REQUESTS[rid] = environ
+
         response = WSGIResponse(
             environ,
             start_response,
@@ -436,14 +443,17 @@ class TaliskerMiddleware():
 
 
 def get_metadata(environ,
-                 status,
-                 headers,
+                 status=None,
+                 headers=None,
                  duration=None,
                  length=None,
                  exc_info=None,
                  filepath=None):
     """Return an ordered dictionary of request metadata for logging."""
-    headers = dict((k.lower(), v) for k, v in headers)
+    if headers is None:
+        headers = {}
+    else:
+        headers = dict((k.lower(), v) for k, v in headers)
     extra = OrderedDict()
     extra['method'] = environ.get('REQUEST_METHOD')
     script = environ.get('SCRIPT_NAME', '')
@@ -452,8 +462,11 @@ def get_metadata(environ,
     qs = environ.get('QUERY_STRING')
     if qs:
         extra['qs'] = environ.get('QUERY_STRING')
-    extra['status'] = status
-    if 'x-view-name' in headers:
+    if status:
+        extra['status'] = status
+    if 'VIEW_NAME' in environ:
+        extra['view'] = environ['VIEW_NAME']
+    elif 'x-view-name' in headers:
         extra['view'] = headers['x-view-name']
     if duration:
         extra['duration_ms'] = round(duration * 1000, 3)
@@ -496,12 +509,13 @@ def get_metadata(environ,
 
 
 def log_response(environ,
-                 status,
-                 headers,
-                 duration,
-                 length,
+                 status=None,
+                 headers=None,
+                 duration=None,
+                 length=None,
                  exc_info=None,
-                 filepath=None):
+                 filepath=None,
+                 **kwargs):
     """Log a WSGI request and record metrics.
 
     Similar to access logs, but structured and with more data."""
@@ -515,6 +529,7 @@ def log_response(environ,
             exc_info,
             filepath,
         )
+        extra.update(kwargs)
         logger.info(msg, extra=extra)
     except Exception:
         logger.exception('error generating access log')
@@ -527,7 +542,7 @@ def log_response(environ,
 
         WSGIMetric.requests.inc(**labels)
         WSGIMetric.latency.observe(extra['duration_ms'], **labels)
-        if status >= 500:
+        if status is None or status >= 500:
             WSGIMetric.errors.inc(**labels)
 
 

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -66,9 +66,9 @@ def test_gunicorn_application_init(monkeypatch):
     app = gunicorn.TaliskerApplication('')
     assert app.cfg.logger_class == gunicorn.GunicornLogger
     assert app.cfg.loglevel.lower() == 'info'
-    assert app.cfg.pre_request is gunicorn.gunicorn_pre_request
     assert app.cfg.on_starting is gunicorn.gunicorn_on_starting
     assert app.cfg.child_exit is gunicorn.gunicorn_child_exit
+    assert app.cfg.worker_exit is gunicorn.gunicorn_worker_exit
     assert logs.get_talisker_handler().level == logging.NOTSET
 
 

--- a/tests/wsgi_app.py
+++ b/tests/wsgi_app.py
@@ -38,6 +38,9 @@ def application(environ, start_response):
     else:
         status = '200 OK'
     start_response(status, [('content-type', 'text/plain')])
+    import time
+    time.sleep(10)
+
     output = pprint.pformat(environ)
     logger = logging.getLogger(__name__)
     logger.debug('debug')

--- a/tests/wsgi_app.py
+++ b/tests/wsgi_app.py
@@ -38,9 +38,6 @@ def application(environ, start_response):
     else:
         status = '200 OK'
     start_response(status, [('content-type', 'text/plain')])
-    import time
-    time.sleep(10)
-
     output = pprint.pformat(environ)
     logger = logging.getLogger(__name__)
     logger.debug('debug')


### PR DESCRIPTION
This means we get a proper log message in the case of timeouts, and
removed the need for the previous pre_request hook to clear contexts