### PR TITLE
Make raven an optional dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VENV = $(VENV_PATH)/ready
 BIN = $(VENV_PATH)/bin
 PY3 = $(shell which python3)
 PYTHON ?= $(shell readlink -f $(PY3))
-TALISKER_EXTRAS=gunicorn,flask,django,celery,prometheus,pg,dev
+TALISKER_EXTRAS=gunicorn,raven,flask,django,celery,prometheus,pg,dev
 LIMBO_REQUIREMENTS=tests/requirements.limbo.txt
 
 default: test

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,12 +45,12 @@ install_requires =
 	Werkzeug>=0.10.4,<0.15
 	statsd>=3.2.1,<4.0
 	requests>=2.16.0,<3.0
-	raven>=6.4.0,<7.0
 	future>=0.15.2,<0.17
 	ipaddress>=1.0.16,<2.0;python_version<"3.3"
 
 [options.extras_require]
 gunicorn = gunicorn>=19.7.0,<20.0
+raven = raven>=6.4.0,<7.0
 celery = 
 	celery>=3.1.25.0,<5.0
 	kombu>=3.0.37,<4.4

--- a/setup.py
+++ b/setup.py
@@ -162,13 +162,15 @@ setup(
         prometheus=[
             'prometheus-client>=0.2.0,<0.5.0,!=0.4.0,!=0.4.1',
         ],
+        raven=[
+            'raven>=6.4.0,<7.0',
+        ],
     ),
     include_package_data=True,
     install_requires=[
         'Werkzeug>=0.10.4,<0.15',
         'statsd>=3.2.1,<4.0',
         'requests>=2.16.0,<3.0',
-        'raven>=6.4.0,<7.0',
         'future>=0.15.2,<0.17',
         'ipaddress>=1.0.16,<2.0;python_version<"3.3"',
     ],

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2015-2018 Canonical, Ltd.
 #
 # This file is part of Talisker
@@ -92,7 +91,8 @@ def initialise(env=os.environ):
     # sentry first, so we can report any further errors in initialisation
     # TODO: add deferred logging, so we can set up sentry first thing
     import talisker.sentry
-    talisker.sentry.get_client()
+    if talisker.sentry.enabled:
+        talisker.sentry.get_client()
     import talisker.statsd
     talisker.statsd.get_client()
     clear_contexts()
@@ -103,9 +103,7 @@ def clear_contexts():
     """Helper to clear any thread local contexts."""
     import talisker.sentry
     clear_context()
-    client = talisker.sentry.get_client()
-    client.context.clear()
-    client.transaction.clear()
+    talisker.sentry.clear()
 
 
 class RunException(Exception):

--- a/talisker/celery.py
+++ b/talisker/celery.py
@@ -238,12 +238,9 @@ def enable_signals():
     signals.task_revoked.connect(task_revoked)
 
     # install celery sentry handlers
-    try:
+    if talisker.sentry.enabled:
         from raven.contrib.celery import CeleryFilter
         from talisker.sentry import get_log_handler
-    except ImportError:
-        pass
-    else:
         sentry_handler = get_sentry_handler()
         if sentry_handler is not None:
             sentry_handler.install()

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -155,8 +155,9 @@ def configure(config):  # pragma: no cover
 
     # sentry integration
     import talisker.sentry  # defer to avoid logging setup
-    sentry_handler = talisker.sentry.get_log_handler()
-    add_talisker_handler(logging.ERROR, sentry_handler)
+    if talisker.sentry.enabled:
+        sentry_handler = talisker.sentry.get_log_handler()
+        add_talisker_handler(logging.ERROR, sentry_handler)
 
     logging_globals['configured'] = True
 
@@ -212,7 +213,10 @@ def enable_debug_log_stderr():
 # our enhanced version of the default raven support for recording breadcrumbs
 def record_log_breadcrumb(record):
     # lazy import avoids any raven loggers being initialised early
-    from raven import breadcrumbs
+    try:
+        from raven import breadcrumbs
+    except ImportError:
+        return
 
     breadcrumb_handler_args = (
         logging.getLogger(record.name),

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -210,51 +210,6 @@ def enable_debug_log_stderr():
     get_talisker_handler().setLevel(logging.DEBUG)
 
 
-# our enhanced version of the default raven support for recording breadcrumbs
-def record_log_breadcrumb(record):
-    # lazy import avoids any raven loggers being initialised early
-    try:
-        from raven import breadcrumbs
-    except ImportError:
-        return
-
-    breadcrumb_handler_args = (
-        logging.getLogger(record.name),
-        record.levelno,
-        record.message,
-        record.args,
-        {
-            'extra': getattr(record, '_structured', {}),
-            'exc_info': record.exc_info,
-            'stack_info': getattr(record, 'stack_info', None)
-        },
-    )
-
-    for handler in getattr(breadcrumbs, 'special_logging_handlers', []):
-        if handler(*breadcrumb_handler_args):
-            return
-
-    handler = breadcrumbs.special_logger_handlers.get(record.name)
-    if handler is not None and handler(*breadcrumb_handler_args):
-        return
-
-    def processor(data):
-        metadata = {
-            'path': record.pathname,
-            'lineno': record.lineno,
-        }
-        if hasattr(record, 'func'):
-            metadata['func'] = record.func
-        metadata.update(getattr(record, '_structured', {}))
-        data.update({
-            'message': record.message,
-            'category': record.name,
-            'level': record.levelname.lower(),
-            'data': metadata,
-        })
-    breadcrumbs.record(processor=processor)
-
-
 class StructuredLogger(logging.Logger):
     """A logger that handles passing 'extra' arguments to all logging calls.
 
@@ -356,13 +311,15 @@ class StructuredFormatter(logging.Formatter):
 
     def format(self, record):
         """Format message with structured tags and any exception/trailer"""
+        import talisker.sentry  # lazy to break import cycle
         try:
             record.message = self.clean_message(record.getMessage())
 
             # we never want sentry to capture DEBUG logs in its breadcrumbs, as
             # they may be sensitive
             if record.levelno > logging.DEBUG:
-                record_log_breadcrumb(record)
+
+                talisker.sentry.record_log_breadcrumb(record)
 
             if len(record.message) > self.MAX_MSG_SIZE:
                 record.message = (

--- a/talisker/postgresql.py
+++ b/talisker/postgresql.py
@@ -42,11 +42,10 @@ except ImportError:
     def format_sql(sql, *args, **kwargs):
         return sql
 
-import raven.breadcrumbs
-
 import talisker
 from talisker.util import get_rounded_ms
 from talisker.context import track_request_metric
+import talisker.sentry
 
 __all__ = [
     'TaliskerConnection',
@@ -129,7 +128,7 @@ class TaliskerConnection(connection):
         breadcrumb = dict(
             message=msg, category='sql', data={}, processor=processor)
 
-        raven.breadcrumbs.record(**breadcrumb)
+        talisker.sentry.record_breadcrumb(**breadcrumb)
 
 
 class TaliskerCursor(cursor):

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -40,7 +40,6 @@ import time
 from future.moves.urllib.parse import parse_qsl, urlsplit, urlunsplit
 
 import future.utils
-import raven.breadcrumbs
 import requests
 from requests.adapters import HTTPAdapter
 import requests.exceptions
@@ -268,7 +267,7 @@ def record_request(request, response=None, exc=None):
     if exc:
         metadata.update(get_errno_fields(exc))
 
-    raven.breadcrumbs.record(
+    talisker.sentry.record_breadcrumb(
         type='http',
         category='requests',
         data=metadata,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,11 @@ import talisker.sentry
 import talisker.testing
 
 # set up test test sentry client
-talisker.testing.configure_sentry_client()
+talisker.sentry.configure_testing(talisker.testing.TEST_SENTRY_DSN)
+
+# create the sentry client up front
+if talisker.sentry.enabled:
+    talisker.sentry.get_client()
 
 
 @pytest.yield_fixture(autouse=True)
@@ -70,7 +74,7 @@ def clean_up(request, tmpdir, monkeypatch, config):
 
     multiproc = tmpdir.mkdir('multiproc')
     monkeypatch.setenv('prometheus_multiproc_dir', str(multiproc))
-    orig_client = talisker.sentry.get_client()
+    orig_client = talisker.sentry._client
 
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,3 +141,16 @@ def no_network(monkeypatch):
         assert 0, "socket.socket was used!"
 
     monkeypatch.setattr(socket, 'socket', bad_socket)
+
+
+try:
+    import raven.context
+except ImportError:
+    @pytest.fixture
+    def get_breadcrumbs():
+        return lambda: None
+else:
+    @pytest.fixture
+    def get_breadcrumbs():
+        with raven.context.Context() as ctx:
+            yield ctx.breadcrumbs.get_buffer

--- a/tests/django_app/django_app/settings.py
+++ b/tests/django_app/django_app/settings.py
@@ -55,7 +55,6 @@ ALLOWED_HOSTS = ['*']
 # Application definition
 
 INSTALLED_APPS = [
-    'raven.contrib.django.raven_compat',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -65,9 +64,16 @@ INSTALLED_APPS = [
     'django_app',
 ]
 
-SENTRY_CLIENT = 'talisker.django.SentryClient'
-SENTRY_TRANSPORT = 'talisker.testing.DummySentryTransport'
-SENTRY_DSN = 'https://user:pass@test.com/project'
+try:
+    import raven  # noqa
+except ImportError:
+    pass
+else:
+    INSTALLED_APPS.insert(0, 'raven.contrib.django.raven_compat')
+    SENTRY_CLIENT = 'talisker.django.SentryClient'
+    SENTRY_TRANSPORT = 'talisker.sentry.DummySentryTransport'
+    SENTRY_DSN = 'https://user:pass@test.com/project'
+
 LOGGING_CONFIG = None
 CELERY_BROKER_URL = 'redis://localhost:6379/0'
 CELERY_ACCEPT_CONTENT = ['json']

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -147,6 +147,7 @@ def test_celery_task_run_retries(celery_app, context):
     ]
 
 
+@pytest.mark.skipif(not talisker.sentry.enabled, reason='need raven installed')
 @freeze_time(DATESTRING)
 def test_celery_sentry(celery_app, context):
     request_id = 'myid'

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -38,10 +38,12 @@ except ImportError:
 
 import talisker.django
 import talisker.sentry
-from talisker.testing import DummySentryTransport, TEST_SENTRY_DSN
+from talisker.testing import TEST_SENTRY_DSN
 
 
+@pytest.mark.skipif(not talisker.sentry.enabled, reason='need raven installed')
 def test_django_sentry_client(monkeypatch, context):
+    from talisker.sentry import DummySentryTransport
     called = [False]
 
     def hook():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -38,7 +38,6 @@ from collections import OrderedDict
 import shlex
 import calendar
 
-import raven.context
 import pytest
 
 from talisker import logs
@@ -180,6 +179,11 @@ def test_make_record_protected(monkeypatch):
 
 
 def test_logger_collects_raven_breadcrumbs():
+    try:
+        import raven.context
+    except ImportError:
+        pytest.skip('need raven installed')
+
     fmt = logs.StructuredFormatter()
     with raven.context.Context() as ctx:
         fmt.format(make_record({'foo': 'bar'}, 'info'))

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -30,7 +30,6 @@ import datetime
 import http.client
 import io
 import itertools
-import raven.context
 import requests
 import responses
 import socket
@@ -90,6 +89,19 @@ def requests_hosts(monkeypatch):
     monkeypatch.setattr(talisker.requests, 'HOSTS', {})
 
 
+try:
+    import raven.context
+except ImportError:
+    @pytest.fixture
+    def breadcrumbs():
+        return None
+else:
+    @pytest.fixture
+    def breadcrumbs():
+        with raven.context.Context() as ctx:
+            yield ctx.breadcrumbs.get_buffer
+
+
 def test_collect_metadata_hostname(requests_hosts):
     talisker.requests.register_endpoint_name('1.2.3.4:8000', 'service')
     req = request(url='/foo/bar', host='http://1.2.3.4:8000')
@@ -143,77 +155,78 @@ def test_collect_metadata_with_response():
     }
 
 
-def test_metric_hook(context):
+def test_metric_hook(context, breadcrumbs):
     r = mock_response(view='view')
 
-    with raven.context.Context() as ctx:
-        talisker.requests.metrics_response_hook(r)
+    talisker.requests.metrics_response_hook(r)
 
     assert context.statsd[0] == 'requests.count.example-com.view:1|c'
     assert context.statsd[1] == (
         'requests.latency.example-com.view.200:1000.000000|ms'
     )
-    breadcrumbs = ctx.breadcrumbs.get_buffer()
-    assert breadcrumbs[0]['type'] == 'http'
-    assert breadcrumbs[0]['category'] == 'requests'
-    assert breadcrumbs[0]['data']['url'] == 'http://example.com/'
-    assert breadcrumbs[0]['data']['host'] == 'example.com'
-    assert breadcrumbs[0]['data']['method'] == 'GET'
-    assert breadcrumbs[0]['data']['view'] == 'view'
-    assert breadcrumbs[0]['data']['status_code'] == 200
-    assert breadcrumbs[0]['data']['duration_ms'] == 1000.0
+
+    if breadcrumbs is not None:
+        breadcrumbs = breadcrumbs()
+        assert breadcrumbs[0]['type'] == 'http'
+        assert breadcrumbs[0]['category'] == 'requests'
+        assert breadcrumbs[0]['data']['url'] == 'http://example.com/'
+        assert breadcrumbs[0]['data']['host'] == 'example.com'
+        assert breadcrumbs[0]['data']['method'] == 'GET'
+        assert breadcrumbs[0]['data']['view'] == 'view'
+        assert breadcrumbs[0]['data']['status_code'] == 200
+        assert breadcrumbs[0]['data']['duration_ms'] == 1000.0
 
 
-def test_metric_hook_user_name(context):
+def test_metric_hook_user_name(context, breadcrumbs):
     r = mock_response(view='view')
 
-    with raven.context.Context() as ctx:
-        talisker.requests._local.metric_api_name = 'api'
-        talisker.requests._local.metric_host_name = 'service'
-        talisker.requests.metrics_response_hook(r)
-        release_local(talisker.requests._local)
+    talisker.requests._local.metric_api_name = 'api'
+    talisker.requests._local.metric_host_name = 'service'
+    talisker.requests.metrics_response_hook(r)
+    release_local(talisker.requests._local)
 
     assert context.statsd[0] == 'requests.count.service.api:1|c'
     assert context.statsd[1] == (
         'requests.latency.service.api.200:1000.000000|ms'
     )
-    breadcrumbs = ctx.breadcrumbs.get_buffer()
-    assert breadcrumbs[0]['type'] == 'http'
-    assert breadcrumbs[0]['category'] == 'requests'
-    assert breadcrumbs[0]['data']['url'] == 'http://example.com/'
-    assert breadcrumbs[0]['data']['host'] == 'example.com'
-    assert breadcrumbs[0]['data']['view'] == 'view'
-    assert breadcrumbs[0]['data']['method'] == 'GET'
-    assert breadcrumbs[0]['data']['status_code'] == 200
-    assert breadcrumbs[0]['data']['duration_ms'] == 1000.0
+    if breadcrumbs is not None:
+        breadcrumbs = breadcrumbs()
+        assert breadcrumbs[0]['type'] == 'http'
+        assert breadcrumbs[0]['category'] == 'requests'
+        assert breadcrumbs[0]['data']['url'] == 'http://example.com/'
+        assert breadcrumbs[0]['data']['host'] == 'example.com'
+        assert breadcrumbs[0]['data']['view'] == 'view'
+        assert breadcrumbs[0]['data']['method'] == 'GET'
+        assert breadcrumbs[0]['data']['status_code'] == 200
+        assert breadcrumbs[0]['data']['duration_ms'] == 1000.0
 
 
-def test_metric_hook_registered_endpoint(requests_hosts, context):
+def test_metric_hook_registered_endpoint(requests_hosts, context, breadcrumbs):
     talisker.requests.register_endpoint_name('1.2.3.4', 'service')
     req = request(host='http://1.2.3.4', url='/foo/bar?a=1')
     resp = mock_response(req, view='view')
 
-    with raven.context.Context() as ctx:
-        talisker.requests.metrics_response_hook(resp)
+    talisker.requests.metrics_response_hook(resp)
 
     assert context.statsd[0] == 'requests.count.service.view:1|c'
     assert context.statsd[1] == (
         'requests.latency.service.view.200:1000.000000|ms'
     )
-    breadcrumbs = ctx.breadcrumbs.get_buffer()
-    assert breadcrumbs[0]['type'] == 'http'
-    assert breadcrumbs[0]['category'] == 'requests'
-    assert breadcrumbs[0]['data']['url'] == 'http://service/foo/bar?'
-    assert breadcrumbs[0]['data']['host'] == 'service'
-    assert breadcrumbs[0]['data']['netloc'] == '1.2.3.4'
-    assert breadcrumbs[0]['data']['method'] == 'GET'
-    assert breadcrumbs[0]['data']['view'] == 'view'
-    assert breadcrumbs[0]['data']['status_code'] == 200
-    assert breadcrumbs[0]['data']['duration_ms'] == 1000.0
+    if breadcrumbs is not None:
+        breadcrumbs = breadcrumbs()
+        assert breadcrumbs[0]['type'] == 'http'
+        assert breadcrumbs[0]['category'] == 'requests'
+        assert breadcrumbs[0]['data']['url'] == 'http://service/foo/bar?'
+        assert breadcrumbs[0]['data']['host'] == 'service'
+        assert breadcrumbs[0]['data']['netloc'] == '1.2.3.4'
+        assert breadcrumbs[0]['data']['method'] == 'GET'
+        assert breadcrumbs[0]['data']['view'] == 'view'
+        assert breadcrumbs[0]['data']['status_code'] == 200
+        assert breadcrumbs[0]['data']['duration_ms'] == 1000.0
 
 
 @responses.activate
-def test_configured_session(context):
+def test_configured_session(context, breadcrumbs):
     session = requests.Session()
     talisker.requests.configure(session)
 
@@ -225,8 +238,7 @@ def test_configured_session(context):
     )
 
     with talisker.request_id.context('XXX'):
-        with raven.context.Context() as ctx:
-            session.get('http://localhost/foo/bar')
+        session.get('http://localhost/foo/bar')
 
     for header_name in responses.calls[0].request.headers:
         assert isinstance(header_name, str)
@@ -234,20 +246,21 @@ def test_configured_session(context):
     assert context.statsd[0] == 'requests.count.localhost.view:1|c'
     assert context.statsd[1].startswith(
         'requests.latency.localhost.view.200:')
-    breadcrumbs = ctx.breadcrumbs.get_buffer()
 
-    assert breadcrumbs[0]['type'] == 'http'
-    assert breadcrumbs[0]['category'] == 'requests'
-    assert breadcrumbs[0]['data']['url'] == 'http://localhost/foo/bar'
-    assert breadcrumbs[0]['data']['host'] == 'localhost'
-    assert breadcrumbs[0]['data']['view'] == 'view'
-    assert breadcrumbs[0]['data']['method'] == 'GET'
-    assert breadcrumbs[0]['data']['status_code'] == 200
-    assert 'duration_ms' in breadcrumbs[0]['data']
+    if breadcrumbs is not None:
+        breadcrumbs = breadcrumbs()
+        assert breadcrumbs[0]['type'] == 'http'
+        assert breadcrumbs[0]['category'] == 'requests'
+        assert breadcrumbs[0]['data']['url'] == 'http://localhost/foo/bar'
+        assert breadcrumbs[0]['data']['host'] == 'localhost'
+        assert breadcrumbs[0]['data']['view'] == 'view'
+        assert breadcrumbs[0]['data']['method'] == 'GET'
+        assert breadcrumbs[0]['data']['status_code'] == 200
+        assert 'duration_ms' in breadcrumbs[0]['data']
 
 
 @responses.activate
-def test_configured_session_http_error(context):
+def test_configured_session_http_error(context, breadcrumbs):
     session = requests.Session()
     talisker.requests.configure(session)
 
@@ -259,33 +272,32 @@ def test_configured_session_http_error(context):
         headers={'X-View-Name': 'view'},
     )
 
-    with raven.context.Context() as ctx:
-        session.get('http://localhost/foo/bar')
+    session.get('http://localhost/foo/bar')
 
     assert context.statsd[0] == 'requests.count.localhost.view:1|c'
     assert context.statsd[1].startswith('requests.latency.localhost.view.500:')
     assert context.statsd[2] == (
         'requests.errors.localhost.http.view.500:1|c'
     )
-    breadcrumbs = ctx.breadcrumbs.get_buffer()
 
-    assert breadcrumbs[0]['type'] == 'http'
-    assert breadcrumbs[0]['category'] == 'requests'
-    assert breadcrumbs[0]['data']['url'] == 'http://localhost/foo/bar'
-    assert breadcrumbs[0]['data']['host'] == 'localhost'
-    assert breadcrumbs[0]['data']['view'] == 'view'
-    assert breadcrumbs[0]['data']['method'] == 'GET'
-    assert breadcrumbs[0]['data']['status_code'] == 500
-    assert 'duration_ms' in breadcrumbs[0]['data']
+    if breadcrumbs is not None:
+        breadcrumbs = breadcrumbs()
+        assert breadcrumbs[0]['type'] == 'http'
+        assert breadcrumbs[0]['category'] == 'requests'
+        assert breadcrumbs[0]['data']['url'] == 'http://localhost/foo/bar'
+        assert breadcrumbs[0]['data']['host'] == 'localhost'
+        assert breadcrumbs[0]['data']['view'] == 'view'
+        assert breadcrumbs[0]['data']['method'] == 'GET'
+        assert breadcrumbs[0]['data']['status_code'] == 500
+        assert 'duration_ms' in breadcrumbs[0]['data']
 
 
-def test_configured_session_connection_error(context):
+def test_configured_session_connection_error(context, breadcrumbs):
     session = requests.Session()
     talisker.requests.configure(session)
 
-    with raven.context.Context() as ctx:
-        with pytest.raises(requests.exceptions.ConnectionError):
-            session.get('http://nope.nowhere/foo')
+    with pytest.raises(requests.exceptions.ConnectionError):
+        session.get('http://nope.nowhere/foo')
 
     assert context.statsd[0] == 'requests.count.nope-nowhere.unknown:1|c'
     assert context.statsd[1].startswith(
@@ -297,17 +309,18 @@ def test_configured_session_connection_error(context):
         context.statsd[1].endswith('EAI_AGAIN:1|c'),
     ))
 
-    breadcrumbs = ctx.breadcrumbs.get_buffer()
-    assert breadcrumbs[-1]['type'] == 'http'
-    assert breadcrumbs[-1]['category'] == 'requests'
-    assert breadcrumbs[-1]['data']['url'] == 'http://nope.nowhere/foo'
-    assert breadcrumbs[-1]['data']['host'] == 'nope.nowhere'
-    assert breadcrumbs[-1]['data']['method'] == 'GET'
-    if 'errno' in breadcrumbs[-1]['data']:
-        assert any((
-            breadcrumbs[-1]['data']['errno'] == 'EAI_NONAME',
-            breadcrumbs[-1]['data']['errno'] == 'EAI_AGAIN',
-        ))
+    if breadcrumbs is not None:
+        breadcrumbs = breadcrumbs()
+        assert breadcrumbs[-1]['type'] == 'http'
+        assert breadcrumbs[-1]['category'] == 'requests'
+        assert breadcrumbs[-1]['data']['url'] == 'http://nope.nowhere/foo'
+        assert breadcrumbs[-1]['data']['host'] == 'nope.nowhere'
+        assert breadcrumbs[-1]['data']['method'] == 'GET'
+        if 'errno' in breadcrumbs[-1]['data']:
+            assert any((
+                breadcrumbs[-1]['data']['errno'] == 'EAI_NONAME',
+                breadcrumbs[-1]['data']['errno'] == 'EAI_AGAIN',
+            ))
 
 
 @responses.activate

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -22,6 +22,13 @@
 # under the License.
 #
 
+import pytest
+
+try:
+    import raven  # noqa
+except ImportError:
+    pytest.skip('skipping sentry tests', allow_module_level=True)
+
 import logging
 import time
 
@@ -44,7 +51,9 @@ DATESTRING = '2016-01-02 03:04:05.1234'
 def create_test_client(**kwargs):
     client = talisker.sentry.TaliskerSentryClient(**kwargs)
     client.set_dsn(
-        testing.TEST_SENTRY_DSN, transport=testing.DummySentryTransport)
+        testing.TEST_SENTRY_DSN,
+        transport=talisker.sentry.DummySentryTransport,
+    )
     return client
 
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -72,6 +72,7 @@ def test_log_record_list():
     assert records.filter(extra={'a': 2}) == []
 
 
+@pytest.mark.skipif(not talisker.sentry.enabled, reason='raven not installed')
 def test_test_context():
 
     assert testing.get_sentry_messages() == []
@@ -98,11 +99,11 @@ def test_test_context():
         ctx.assert_log(name=logger.name, msg='XXX', level='info')
 
     assert str(exc.value) == textwrap.dedent("""
-        Could not find log out of 3 logs:
-            msg={0}'XXX' (0 matches)
-            level={0}'info' (1 matches)
+        Could not find log out of {0} logs:
+            msg={1}'XXX' (0 matches)
+            level={1}'info' (2 matches)
             name='test_test_context' (2 matches)
-    """).strip().format('u' if sys.version_info[0] == 2 else '')
+    """).strip().format(len(ctx.logs), 'u' if sys.version_info[0] == 2 else '')
 
     with pytest.raises(AssertionError) as exc:
         ctx.assert_not_log(name=logger.name, msg='foo', level='info')

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps = -r{toxinidir}/requirements.tests.txt
 commands = py.test -n auto --cov=talisker
 extras = 
     gunicorn
+    raven
     flask
     django
     celery


### PR DESCRIPTION
This involves consolidating all the raven imports and direct API usage
into talisker.sentry module, and providing APIs for the rest of Talisker
to use that do nothing when raven is not installed.