### PR TITLE
Fix importing issues with talisker.run

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -76,6 +76,19 @@ def test_module_entrypoint(script):
     assert 'foo=bar' in output
 
 
+def test_run_sysexit(tmpdir):
+    path = tmpdir.join('test.py')
+    path.write('import sys; sys.exit(2)')
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        subprocess.check_output(
+            ['talisker.run', str(path)],
+            stderr=subprocess.STDOUT,
+        )
+
+    assert e.value.returncode == 2
+    assert b'SystemExit' in e.value.output
+
+
 def test_gunicorn_entrypoint():
     try:
         import gunicorn  # noqa


### PR DESCRIPTION
Use runpy.run_path to execute with __name__ = ' __main__'. Not sure why
I did not do this initially.

Also noticed that sys.exit calls in the script would not get exception
logging, so fixed that as well.