### PR TITLE
Add TALISKER_STATUS_INTERFACE config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint: $(VENV)
 	$(BIN)/flake8 talisker tests
 
 _test: $(VENV)
-	. $(BIN)/activate && $(BIN)/pytest -n auto --timeout=15 $(ARGS)
+	. $(BIN)/activate && $(BIN)/pytest -n auto --timeout=15 --no-success-flaky-report $(ARGS)
 
 TEST_FILES = $(shell find tests -maxdepth 1 -name test_\*.py  | cut -c 7- | cut -d. -f1)
 $(TEST_FILES): $(VENV)

--- a/talisker/config.py
+++ b/talisker/config.py
@@ -294,6 +294,11 @@ class Config():
         networks = [ip_network(force_unicode(n)) for n in network_tokens]
         return networks
 
+    @config_property('TALISKER_STATUS_INTERFACE')
+    def status_interface(self, raw_name):
+        """Which network interface to respond to /_status requests on."""
+        return self[raw_name]
+
     @config_property('TALISKER_REVISION_ID')
     def revision_id(self, raw_name):
         """Sets the explicit revision of the application. If not set, a best

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -72,6 +72,22 @@ def test_gunicorn_eventlet_worker():
 
 
 @require_module('gunicorn')
+def test_gunicorn_status_interface():
+    args = ['--bind', '127.0.0.2:0']  # additional bind
+    env = os.environ.copy()
+    env['TALISKER_REVISION_ID'] = 'test-rev-id'
+    env['TALISKER_STATUS_INTERFACE'] = '127.0.0.2'
+    with GunicornProcess('tests.wsgi_app:app404', args=args, env=env) as p:
+        resp1 = requests.get(p.url('/_status/check', iface='127.0.0.1'))
+        resp2 = requests.get(p.url('/_status/check', iface='127.0.0.2'))
+    assert resp1.status_code == 404
+    assert resp1.text == 'Not Found'
+    assert resp2.status_code == 200
+    assert resp2.text == 'test-rev-id\n'
+
+
+@require_module('flask')
+@require_module('gunicorn')
 def test_flask_app():
     try:
         import flask  # noqa
@@ -85,6 +101,7 @@ def test_flask_app():
 
 
 @require_module('gunicorn')
+@require_module('django')
 def test_django_app(django):
     try:
         import django  # noqa

--- a/tests/wsgi_app.py
+++ b/tests/wsgi_app.py
@@ -46,3 +46,12 @@ def application(environ, start_response):
     logger.error('error')
     logger.critical('critical')
     return [output.encode('utf8')]
+
+
+def app404(environ, start_response):
+    if environ['PATH_INFO'] == '/_status/ping':
+        start_response('200 OK', [])
+        return [b'OK']
+    else:
+        start_response('404 Not Found', [])
+        return [b'Not Found']

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skipsdist = True
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 usedevelop = True
 deps = -r{toxinidir}/requirements.tests.txt
-commands = py.test -n auto --cov=talisker
+commands = py.test -n auto --cov=talisker --no-success-flaky-report
 extras =
     gunicorn
     raven


### PR DESCRIPTION
This allows /_status endpoints to only respond on that interface.

Includes refactor of GunicornProcess to support binding to multiple
interfaces.

Fixes #467 