### PR TITLE
Support per-request deadlines in network stack

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -8,8 +8,8 @@ in Python 3.7+, falling back to the contextvars backport from PyPI. It
 also includes a minimal backport of ContextVar for use with Python 2.
 
 Talisker creates a new context for each WSGI request or Celery job, and
-tracks the request id and other data in that context. Asyncio is
-supported, either by the native support in python 3.7, or via the
+tracks the request id and other data in that context, such as timeout data.
+Asyncio is supported, either by the native support in python 3.7, or via the
 aiocontextvars package, which you can install by using the asyncio
 extra::
 
@@ -22,7 +22,7 @@ Talisker also explicitly supports contexts when using the Gevent or
 Eventlet Gunicorn workers, by swapping the thread local storage out for
 the relative greenlet based storage. This support currently does not
 work in python 3.7 or above, as it is not possible to switch the
-underlying storage.
+underlying storage in the stdlib version of the contextvars library.
 
 
 Request Id
@@ -50,15 +50,15 @@ distributed systems.
 Context API
 -----------
 
-Talisker exposes a public API for the current context::
+Talisker exposes a public API for the current context.
 
-.. highlight:: python
+.. code-block:: python
 
     from talisker import Context
 
-    Context.request_id              # get/set current request id
-    Context.clear()                 # clear the current context
-    Context.new()                   # create a new context
+    Context.request_id          # get/set current request id
+    Context.clear()             # clear the current context
+    Context.new()               # create a new context
 
     # you can also add extras to the current logging context
 
@@ -68,4 +68,3 @@ Talisker exposes a public API for the current context::
 
     with Context.logging(bar=2):
         ...
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Contents:
    gunicorn
    sentry
    endpoints
+   timeouts
    requests
    statsd
    prometheus

--- a/docs/timeouts.rst
+++ b/docs/timeouts.rst
@@ -1,0 +1,66 @@
+================
+Request Timeouts
+================
+
+Talisker supports the idea of a request deadline, with the goal of
+failing early, especially when under load. This deadline can be
+specified as a timeout, either globaly or per-endpoint.
+
+Talisker will try to use the remaining time left until the deadline as
+network timeout parameters. It supports HTTP and SQL requests out of the
+box, if you use `talisker.requests.TaliskerAdapter` and
+`talisker.postgresql.TaliskerConnecton`, respectivley. It also provides
+an API to get the remaining time left before the deadline, which you can
+use in other network operations.
+
+.. code-block:: python
+
+    timeout = Context.deadline_timeout()
+
+Note: this will raise `talisker.DeadlineExceeded` if the deadline has
+been exceeded.
+
+Talisker timeouts are not hard guarantees - Talisker will not cancel
+your request. They merely try to ensure that network operations will
+fail earlier rather than blocking for long periods.
+
+Deadline Propagation
+--------------------
+
+The deadline can be set via a the X-Request-Deadline request header, as
+an ISO 8601 datestring.  This will override the configured endpoint
+deadline, if any. Talisker's requests support will also send the current
+deadline as a header in any outgoing requests. This allows API gateway
+services to communicate top-level request deadlines ina calls to other
+services.
+
+
+Configuring Timeouts
+--------------------
+
+You can set a global timeout via the TALISKER_REQUEST_TIMEOUT config, or
+per endpoint with the `talisker.request_timeout` decorator.
+
+.. code-block:: python
+
+    @talisker.request_timeout(3000)  # milliseconds
+    def view(request):
+        ...
+
+
+Soft Timeouts
+-------------
+
+Talisker supports the concept of a `soft_timeout`, which will
+send a sentry report if a request takes longer than the soft timeout
+threshold. This is useful to provide richer information for problematic
+requests.
+
+You can set this global via the TALISKER_SOFT_REQUEST_TIMEOUT
+config or per endpoint via the `talisker.request_timeout` decorator.
+
+.. code-block:: python
+
+    @talisker.request_timeout(soft_timeout=3000)  # milliseconds
+    def view(request):
+        ...

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -42,8 +42,9 @@ from talisker.util import (
     pkg_is_installed,
     flush_early_logs
 )
-from talisker.context import (
+from talisker.context import (  # NOQA
     Context,
+    DeadlineExceeded,
     enable_gevent_context,
     enable_eventlet_context,
 )

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -45,8 +45,7 @@ from talisker.util import (
 from talisker.context import (  # NOQA
     Context,
     DeadlineExceeded,
-    enable_gevent_context,
-    enable_eventlet_context,
+    request_timeout,
 )
 
 __version__ = '0.14.2'
@@ -54,6 +53,8 @@ __all__ = [
     'initialise',
     'get_config',
     'Context',
+    'DeadlineExceeded',
+    'request_timeout',
 ]
 prometheus_multiproc_cleanup = False
 
@@ -226,6 +227,7 @@ def run_gunicorn():
             )
     try:
         from gunicorn.workers.ggevent import GeventWorker
+        from talisker.context import enable_gevent_context
     except ImportError:
         pass
     else:
@@ -234,6 +236,7 @@ def run_gunicorn():
 
     try:
         from gunicorn.workers.geventlet import EventletWorker
+        from talisker.context import enable_eventlet_context
     except ImportError:
         pass
     else:

--- a/talisker/config.py
+++ b/talisker/config.py
@@ -270,14 +270,20 @@ class Config():
         A soft timeout is simply a warning-level sentry report for the request.
         The aim is to provide early warning and context for when things exceed
         some limit.
+
+        Note: this can be set on a per-endpoint basis using the
+        `talisker.request_timeout` decorator.
         """
         return force_int(self[raw_name])
 
     @config_property('TALISKER_REQUEST_TIMEOUT')
     def request_timeout(self, raw_name):
-        """Set a deadline for all request. Any network requests that talisker
+        """Set a deadline for all requests. Any network requests that talisker
         suports (requests, psycopg2) will have their timeouts set to this
         deadline.
+
+        Note: this can be set on a per-endpoint basis using the
+        `talisker.request_timeout` decorator.
         """
         return force_int(self[raw_name])
 

--- a/talisker/config.py
+++ b/talisker/config.py
@@ -53,7 +53,9 @@ __all__ = ['get_config']
 
 # All valid config
 CONFIG_META = collections.OrderedDict()
-CONFIG_ALIASES = {'TALISKER_COLOUR': 'TALISKER_COLOR'}
+CONFIG_ALIASES = {
+    'TALISKER_COLOUR': 'TALISKER_COLOR',
+}
 # A cache of calculated config values
 CONFIG_CACHE = module_dict()
 # Collect any configuration errors
@@ -199,8 +201,7 @@ class Config():
         """Allows coloured logs, warnings, and other development convieniences.
 
         DEVEL mode enables coloured log output, enables python warnings and,
-        for gunicorn, it sets longer timeouts, enables access logs, and auto
-        reload by default.
+        for gunicorn, it sets longer timeouts and auto reloads by default.
         """
         return self.is_active(raw_name)
 
@@ -269,6 +270,14 @@ class Config():
         A soft timeout is simply a warning-level sentry report for the request.
         The aim is to provide early warning and context for when things exceed
         some limit.
+        """
+        return force_int(self[raw_name])
+
+    @config_property('TALISKER_REQUEST_TIMEOUT')
+    def request_timeout(self, raw_name):
+        """Set a deadline for all request. Any network requests that talisker
+        suports (requests, psycopg2) will have their timeouts set to this
+        deadline.
         """
         return force_int(self[raw_name])
 

--- a/talisker/config.py
+++ b/talisker/config.py
@@ -128,6 +128,7 @@ class Config():
         'TALISKER_SOFT_REQUEST_TIMEOUT': -1,
         'TALISKER_NETWORKS': [],
         'TALISKER_ID_HEADER': 'X-Request-Id',
+        'TALISKER_DEADLINE_HEADER': 'X-Request-Deadline',
     }
 
     Metadata = collections.namedtuple(
@@ -375,6 +376,11 @@ class Config():
     @config_property('TALISKER_ID_HEADER')
     def id_header(self, raw_name):
         """Header containing request id. Defaults to X-Request-Id."""
+        return text_to_native_str(self[raw_name])
+
+    @config_property('TALISKER_DEADLINE_HEADER')
+    def deadline_header(self, raw_name):
+        """Header for request deadline. Defaults to X-Request-Deadline."""
         return text_to_native_str(self[raw_name])
 
     @property

--- a/talisker/context.py
+++ b/talisker/context.py
@@ -38,6 +38,7 @@ except ImportError:  # py2
 
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
+import functools
 import sys
 import threading
 import time
@@ -314,3 +315,22 @@ class ContextStack(Mapping):
     def __iter__(self):
         """Iterate from top to bottom, preserving individual dict ordering."""
         return iter(self.flat)
+
+
+class request_timeout():
+    def __init__(self, timeout=None, soft_timeout=None):
+        self.timeout = timeout
+        self.soft_timeout = soft_timeout
+
+    def __call__(self, f):
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            if self.timeout:
+                Context.current.set_deadline(self.timeout)
+            if self.soft_timeout:
+                Context.current.soft_timeout = self.soft_timeout
+
+            return f(*args, **kwargs)
+
+        return wrapper

--- a/talisker/context.py
+++ b/talisker/context.py
@@ -198,6 +198,11 @@ class ContextAPI():
             ContextId.set(None)
 
     def new(self):
+        """Clear current context and explicitly create new one.
+
+        This is to force the context creation timestamp to be at a particular
+        point.
+        """
         self.clear()
         ctx = create_context()
         ContextId.set(ctx.id)

--- a/talisker/postgresql.py
+++ b/talisker/postgresql.py
@@ -32,9 +32,8 @@ from builtins import *  # noqa
 import collections
 import logging
 import time
-import shlex
 
-import psycopg2.errors
+import psycopg2
 from psycopg2.extensions import cursor, connection
 
 try:
@@ -69,23 +68,24 @@ def prettify_sql(sql):
         indent_tabs=False)
 
 
-def get_safe_connection_string(conn):
-    try:
-        try:
-            # 2.7+
-            params = conn.get_dsn_parameters()
-        except AttributeError:
-            params = dict(i.split('=') for i in shlex.split(conn.dsn))
-
-        params.setdefault('host', 'localhost')
-        return '{user}@{host}:{port}/{dbname}'.format(**params)
-    except Exception:
-        return 'could not parse dsn'
-
-
 class TaliskerConnection(connection):
     _logger = None
     _threshold = None
+    _safe_dsn = None
+    _safe_dsn_format = '{user}@{host}:{port}/{dbname}'
+
+    @property
+    def safe_dsn(self):
+        if self._safe_dsn is None:
+            try:
+                params = self.get_dsn_parameters()
+                params.setdefault('host', 'localhost')
+                self._safe_dsn = self._safe_dsn_format.format(**params)
+            except Exception:
+                self.logger.exception('Failed to parse DSN')
+                self._safe_dsn = 'could not parse dsn'
+
+        return self._safe_dsn
 
     @property
     def logger(self):
@@ -110,28 +110,22 @@ class TaliskerConnection(connection):
         query = FILTERED if query is None else query
         return query
 
-    def _record(self, msg, query, duration, timeout=None, cancelled=False):
+    def _record(self, msg, query, duration, extra={}):
         talisker.Context.track('sql', duration)
 
+        qdata = collections.OrderedDict()
+        qdata['duration_ms'] = duration
+        qdata['connection'] = self.safe_dsn
+        qdata.update(extra)
+
         if self.query_threshold >= 0 and duration > self.query_threshold:
-            extra = collections.OrderedDict()
-            extra['trailer'] = self._format_query(query)
-            extra['duration_ms'] = duration
-            extra['connection'] = get_safe_connection_string(self)
-            if timeout:
-                extra['timeout'] = timeout
-            if cancelled:
-                extra['cancelled'] = True
-            self.logger.info('slow ' + msg, extra=extra)
+            formatted = self._format_query(query)
+            self.logger.info(
+                'slow ' + msg, extra=dict(qdata, trailer=formatted))
 
         def processor(data):
-            data['data']['query'] = self._format_query(query)
-            data['data']['duration'] = duration
-            data['data']['connection'] = get_safe_connection_string(self)
-            if timeout:
-                data['data']['timeout'] = timeout
-            if cancelled:
-                data['data']['cancelled'] = True
+            qdata['query'] = self._format_query(query)
+            data['data'].update(qdata)
 
         breadcrumb = dict(
             message=msg, category='sql', data={}, processor=processor)
@@ -141,7 +135,7 @@ class TaliskerConnection(connection):
 
 class TaliskerCursor(cursor):
 
-    def apply_timeout(self, query):
+    def apply_timeout(self):
         ctx_timeout = talisker.Context.deadline_timeout()
         if ctx_timeout is None:
             return None
@@ -153,28 +147,41 @@ class TaliskerCursor(cursor):
         return ms
 
     def execute(self, query, vars=None):
-        timeout = self.apply_timeout(query)
+        extra = collections.OrderedDict()
+        timeout = self.apply_timeout()
+        if timeout:
+            extra['timeout'] = timeout
         timestamp = time.time()
-        cancelled = False
         try:
             return super(TaliskerCursor, self).execute(query, vars)
-        except psycopg2.errors.QueryCanceled:
-            cancelled = True
+        except psycopg2.OperationalError as exc:
+            extra['pgcode'] = exc.pgcode
+            extra['pgerror'] = exc.pgerror
+            if exc.pgcode == '57014':
+                extra['timedout'] = True
             raise
         finally:
             duration = get_rounded_ms(timestamp)
             if vars is None:
                 query = None
-            self.connection._record(
-                'query', query, duration, timeout, cancelled
-            )
+            self.connection._record('query', query, duration, extra)
 
     def callproc(self, procname, vars=None):
+        extra = collections.OrderedDict()
+        timeout = self.apply_timeout()
+        if timeout:
+            extra['timeout'] = timeout
         timestamp = time.time()
         try:
             return super(TaliskerCursor, self).callproc(procname, vars)
+        except psycopg2.OperationalError as exc:
+            extra['pgcode'] = exc.pgcode
+            extra['pgerror'] = exc.pgerror
+            if exc.pgcode == '57014':
+                extra['timedout'] = True
+            raise
         finally:
             duration = get_rounded_ms(timestamp)
             # no query parameters, cannot safely record
             self.connection._record(
-                'stored proc: {}'.format(procname), None, duration)
+                'stored proc: {}'.format(procname), None, duration, extra)

--- a/talisker/postgresql.py
+++ b/talisker/postgresql.py
@@ -149,7 +149,7 @@ class TaliskerCursor(cursor):
     def execute(self, query, vars=None):
         extra = collections.OrderedDict()
         timeout = self.apply_timeout()
-        if timeout:
+        if timeout is not None:
             extra['timeout'] = timeout
         timestamp = time.time()
         try:
@@ -169,7 +169,7 @@ class TaliskerCursor(cursor):
     def callproc(self, procname, vars=None):
         extra = collections.OrderedDict()
         timeout = self.apply_timeout()
-        if timeout:
+        if timeout is not None:
             extra['timeout'] = timeout
         timestamp = time.time()
         try:

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -167,7 +167,7 @@ def send_wrapper(func):
             request.headers[config.id_header] = rid
         if Context.current.deadline:
             deadline = datetime.fromtimestamp(Context.current.deadline)
-            request.headers['X-Request-Deadline'] = deadline.isoformat()
+            request.headers[config.deadline_header] = deadline.isoformat()
         try:
             return func(request, **kwargs)
         except Exception as e:

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 import collections
+from datetime import datetime
 import functools
 import itertools
 import logging
@@ -52,6 +53,7 @@ import urllib3.exceptions
 from urllib3.util import Retry
 
 import talisker
+from talisker import Context
 import talisker.metrics
 from talisker.util import (
     get_errno_fields,
@@ -160,9 +162,12 @@ def send_wrapper(func):
 
     @functools.wraps(func)
     def send(request, **kwargs):
-        rid = talisker.Context.request_id
+        rid = Context.request_id
         if rid and config.id_header not in request.headers:
             request.headers[config.id_header] = rid
+        if Context.current.deadline:
+            deadline = datetime.fromtimestamp(Context.current.deadline)
+            request.headers['X-Request-Deadline'] = deadline.isoformat()
         try:
             return func(request, **kwargs)
         except Exception as e:
@@ -177,7 +182,7 @@ def request_wrapper(func):
     """Adds support for metric_name kwarg to session."""
     @functools.wraps(func)
     def request(method, url, **kwargs):
-        ctx = talisker.Context.current
+        ctx = Context.current
         try:
             ctx.metric_api_name = kwargs.pop('metric_api_name', None)
             ctx.metric_host_name = kwargs.pop('metric_host_name', None)
@@ -262,7 +267,7 @@ def metrics_response_hook(response, **kwargs):
 def record_request(request, response=None, exc=None):
     metadata = collect_metadata(request, response)
     if response:
-        talisker.Context.track('http', metadata['duration_ms'])
+        Context.track('http', metadata['duration_ms'])
 
     if exc:
         metadata.update(get_errno_fields(exc))
@@ -278,7 +283,7 @@ def record_request(request, response=None, exc=None):
         'view': metadata.get('view', 'unknown'),
     }
 
-    ctx = talisker.Context.current
+    ctx = Context.current
     metric_api_name = getattr(ctx, 'metric_api_name', None)
     metric_host_name = getattr(ctx, 'metric_host_name', None)
     if metric_api_name is not None:
@@ -418,6 +423,12 @@ class TaliskerAdapter(HTTPAdapter):
                         'or two float/ints and a urllib3.Retry'
                     )
 
+        # enforce any context deadline
+        ctx_timeout = Context.deadline_timeout()
+        if ctx_timeout is not None:
+            connect = min(connect, ctx_timeout)
+            read = min(read, ctx_timeout)
+
         # ensure urllib3 timeout
         kwargs['timeout'] = (connect, read)
 
@@ -441,9 +452,9 @@ class TaliskerAdapter(HTTPAdapter):
 
             error = exc.args[0]
             if isinstance(error, urllib3.exceptions.MaxRetryError):
+                # we need the original urllib3 exception base error
                 error = error.reason
             try:
-                # we need the original urllib3 exception base error
                 request._retry = request._retry.increment(
                     request.method,
                     request.url,
@@ -469,7 +480,7 @@ class TaliskerAdapter(HTTPAdapter):
                 # which we do not want. So we explicitly reraise the original
                 # ConnectionError. In py3, this would not be desirable, as the
                 # exception context would be confused, by py2 does not do
-                # chained exceptins, so, erm, yay?
+                # chained exceptions, so, erm, yay?
                 if future.utils.PY3:
                     raise  # raises the original ConnectionError
                 else:

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -166,8 +166,9 @@ def send_wrapper(func):
         if rid and config.id_header not in request.headers:
             request.headers[config.id_header] = rid
         if Context.current.deadline:
-            deadline = datetime.fromtimestamp(Context.current.deadline)
-            request.headers[config.deadline_header] = deadline.isoformat()
+            deadline = datetime.utcfromtimestamp(Context.current.deadline)
+            formatted = deadline.isoformat() + 'Z'
+            request.headers[config.deadline_header] = formatted
         try:
             return func(request, **kwargs)
         except Exception as e:

--- a/talisker/util.py
+++ b/talisker/util.py
@@ -39,7 +39,7 @@ import time
 
 import werkzeug.local
 from future.moves.urllib.parse import urlparse
-from future.utils import text_to_native_str
+import future.utils
 
 
 # look up table for errno's
@@ -119,13 +119,13 @@ def force_unicode(s):
 
 def set_wsgi_header(headers, name, value):
     """Replace a wsgi header, ensuring correct encoding"""
-    native_name = text_to_native_str(name)
+    native_name = future.utils.text_to_native_str(name)
     for i, (k, v) in enumerate(headers):
         if native_name == k:
-            headers[i] = (native_name, text_to_native_str(value))
+            headers[i] = (native_name, future.utils.text_to_native_str(value))
             return
 
-    headers.append((native_name, text_to_native_str(value)))
+    headers.append((native_name, future.utils.text_to_native_str(value)))
 
 
 def get_rounded_ms(start_time, now_time=None):
@@ -256,3 +256,11 @@ def get_errno_fields(exc):
     if getattr(root, 'filename2', None) is not None:
         fields['filename2'] = root.filename2
     return fields
+
+
+if future.utils.PY3:
+    def datetime_to_timestamp(dt):
+        return dt.timestamp()
+else:
+    def datetime_to_timestamp(dt):
+        time.mktime(dt.utctimetuple())

--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -433,7 +433,7 @@ class TaliskerMiddleware():
             try:
                 deadline = datetime.strptime(
                     header_deadline,
-                    "%Y-%m-%dT%H:%M:%S.%f",
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
                 )
             except ValueError:
                 pass

--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 __metaclass__ = type
 
+
 from collections import OrderedDict
 from datetime import datetime
 import logging
@@ -43,7 +44,7 @@ from talisker.context import Context
 import talisker.endpoints
 import talisker.requests
 import talisker.statsd
-from talisker.util import set_wsgi_header
+from talisker.util import set_wsgi_header, datetime_to_timestamp
 from talisker.render import (
     Content,
     Table,
@@ -439,7 +440,7 @@ class TaliskerMiddleware():
             else:
                 # set deadline directly
                 # TODO: validate deadline is in future?
-                Context.current.deadline = deadline.timestamp()
+                Context.current.deadline = datetime_to_timestamp(deadline)
                 set_deadline = True
 
         if not set_deadline and config.request_timeout is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,7 @@ def test_config_defaults():
         colour=False,
         slowquery_threshold=-1,
         soft_request_timeout=-1,
+        request_timeout=None,
         logstatus=False,
         networks=[],
         id_header='X-Request-Id',

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -221,7 +221,7 @@ def test_metric_hook_registered_endpoint(
 @responses.activate
 def test_configured_session(context, get_breadcrumbs):
     deadline = time.time() + 10
-    expected_deadline = datetime.fromtimestamp(deadline).isoformat()
+    expected_deadline = datetime.utcfromtimestamp(deadline).isoformat() + 'Z'
     Context.current.deadline = deadline
     session = requests.Session()
     talisker.requests.configure(session)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -21,12 +21,16 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
-from datetime import timedelta
-from io import StringIO
+from builtins import *  # noqa
+from future.utils import native_str
 
 from collections import namedtuple
-import datetime
+from datetime import datetime, timedelta
 import http.client
 import io
 import itertools
@@ -67,7 +71,7 @@ def mock_response(
     resp.elapsed = timedelta(seconds=elapsed)
     resp.headers['Server'] = 'test/1.0'
     if body is not None:
-        resp.raw = StringIO(body)
+        resp.raw = io.StringIO(body)
         resp.headers['Content-Length'] = len(body)
         resp.headers['Content-Type'] = content_type
     if view is not None:
@@ -217,7 +221,7 @@ def test_metric_hook_registered_endpoint(
 @responses.activate
 def test_configured_session(context, get_breadcrumbs):
     deadline = time.time() + 10
-    expected_deadline = datetime.datetime.fromtimestamp(deadline).isoformat()
+    expected_deadline = datetime.fromtimestamp(deadline).isoformat()
     Context.current.deadline = deadline
     session = requests.Session()
     talisker.requests.configure(session)
@@ -233,7 +237,7 @@ def test_configured_session(context, get_breadcrumbs):
         session.get('http://localhost/foo/bar')
 
     for header_name in responses.calls[0].request.headers:
-        assert isinstance(header_name, str)
+        assert isinstance(header_name, native_str)
     headers = responses.calls[0].request.headers
     assert headers['X-Request-Id'] == 'XXX'
     assert headers['X-Request-Deadline'] == expected_deadline
@@ -332,7 +336,7 @@ def test_configured_session_with_user_name(context):
         )
 
     for header_name in responses.calls[0].request.headers:
-        assert isinstance(header_name, str)
+        assert isinstance(header_name, native_str)
     assert responses.calls[0].request.headers['X-Request-Id'] == 'XXX'
     assert context.statsd[0].startswith('requests.count.service.api:')
     assert context.statsd[1].startswith('requests.latency.service.api.200:')
@@ -496,7 +500,7 @@ class Urllib3Mock:
         assert self.response_iter, 'no responses set'
 
         response, latency = next(self.response_iter)
-        self.frozen_time.tick(datetime.timedelta(seconds=latency))
+        self.frozen_time.tick(timedelta(seconds=latency))
 
         if isinstance(response, Exception):
             raise response
@@ -519,7 +523,7 @@ def mock_urllib3(monkeypatch):
     mock = Urllib3Mock(frozen)
 
     def sleep(amount):
-        frozen.tick(datetime.timedelta(seconds=amount))
+        frozen.tick(timedelta(seconds=amount))
 
     # use a function to wrap the method, so we preserve original calling self
     # reference, rather than our method's self.

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -39,6 +39,7 @@ import pytest
 from freezegun import freeze_time
 
 from talisker import wsgi, Context
+from talisker.util import datetime_to_timestamp
 import talisker.sentry
 
 
@@ -136,6 +137,7 @@ def test_wsgi_response_start_response(wsgi_env, start_response):
         ('X-Request-Id', 'ID'),
     ]
     assert start_response.exc_info is response.exc_info is None
+
 
 def test_wsgi_response_soft_timeout_default(wsgi_env, start_response, context):
     with freeze_time() as frozen:
@@ -346,7 +348,7 @@ def test_middleware_sets_header_deadline(wsgi_env, start_response, config):
     mw = wsgi.TaliskerMiddleware(app, {}, {})
     list(mw(wsgi_env, start_response))
 
-    assert contexts[0].deadline == ts.timestamp()
+    assert contexts[0].deadline == datetime_to_timestamp(ts)
 
 
 def test_middleware_error_before_start_response(

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -344,7 +344,7 @@ def test_middleware_sets_header_deadline(wsgi_env, start_response, config):
         return [b'OK']
 
     ts = datetime.utcnow() + timedelta(seconds=10)
-    wsgi_env['HTTP_X_REQUEST_DEADLINE'] = ts.isoformat()
+    wsgi_env['HTTP_X_REQUEST_DEADLINE'] = ts.isoformat() + 'Z'
     mw = wsgi.TaliskerMiddleware(app, {}, {})
     list(mw(wsgi_env, start_response))
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -29,6 +29,7 @@ from __future__ import absolute_import
 
 from builtins import *  # noqa
 
+from datetime import datetime, timedelta
 import json
 import sys
 import time
@@ -136,7 +137,6 @@ def test_wsgi_response_start_response(wsgi_env, start_response):
     ]
     assert start_response.exc_info is response.exc_info is None
 
-
 def test_wsgi_response_soft_timeout_default(wsgi_env, start_response, context):
     with freeze_time() as frozen:
         wsgi_env['start_time'] = time.time()
@@ -151,16 +151,16 @@ def test_wsgi_response_soft_timeout_default(wsgi_env, start_response, context):
 @pytest.mark.skipif(not talisker.sentry.enabled, reason='need raven installed')
 def test_wsgi_response_soft_explicit(wsgi_env, start_response, context):
     with freeze_time() as frozen:
+        talisker.Context.current.soft_timeout = 100
         wsgi_env['start_time'] = time.time()
-        response = wsgi.WSGIResponse(wsgi_env, start_response, [], 100)
+        response = wsgi.WSGIResponse(wsgi_env, start_response, [])
         frozen.tick(2.0)
         response.start_response('200 OK', [], None)
         list(response.wrap([b'']))
 
-    assert (
-        context.sentry[0]['message'] == 'Start_response over timeout: 100ms'
-    )
-    assert context.sentry[0]['level'] == 'warning'
+    msg = context.sentry[0]
+    assert msg['message'] == 'start_response over soft timeout: 100ms'
+    assert msg['level'] == 'warning'
 
 
 @freeze_time('2016-01-02 03:04:05.1234')
@@ -306,7 +306,47 @@ def test_middleware_basic(wsgi_env, start_response, context):
         ('X-Request-Id', 'ID'),
     ]
 
-    context.assert_log(name='talisker.wsgi', msg='GET /')
+    context.assert_log(
+        name='talisker.wsgi',
+        msg='GET /',
+        extra={'request_id': 'ID'},
+    )
+
+
+def test_middleware_sets_deadlines(wsgi_env, start_response, config):
+    config['TALISKER_SOFT_REQUEST_TIMEOUT'] = 1000
+    config['TALISKER_REQUEST_TIMEOUT'] = 2000
+
+    contexts = []
+
+    def app(environ, _start_response):
+        contexts.append(Context.current)
+        _start_response('200 OK', [('Content-Type', 'text/plain')])
+        return [b'OK']
+
+    mw = wsgi.TaliskerMiddleware(app, {}, {})
+    list(mw(wsgi_env, start_response))
+
+    assert contexts[0].soft_timeout == 1000
+    assert contexts[0].deadline == contexts[0].start_time + 2.0
+
+
+def test_middleware_sets_header_deadline(wsgi_env, start_response, config):
+    config['TALISKER_REQUEST_TIMEOUT'] = 2000
+
+    contexts = []
+
+    def app(environ, _start_response):
+        contexts.append(Context.current)
+        _start_response('200 OK', [('Content-Type', 'text/plain')])
+        return [b'OK']
+
+    ts = datetime.utcnow() + timedelta(seconds=10)
+    wsgi_env['HTTP_X_REQUEST_DEADLINE'] = ts.isoformat()
+    mw = wsgi.TaliskerMiddleware(app, {}, {})
+    list(mw(wsgi_env, start_response))
+
+    assert contexts[0].deadline == ts.timestamp()
 
 
 def test_middleware_error_before_start_response(


### PR DESCRIPTION
This uses the new context api to set soft timeouts on a per-request basis, rather than just globally.

It also adds a new concept: request deadlines. If a deadline is set, this ensure that any network operation Talisker knows about (currently requests and psycopg2) has its timeout set to match the deadline.  Deadlines can be set globally, per api, or via X-Request-Deadline header. 

Talisker will also include the current request deadline as a header in any outgoing requests.
