### PR TITLE
refactor wsgi request logging, for more context

### DIFF
--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -116,13 +116,9 @@ def gunicorn_child_exit(server, worker):
 def gunicorn_worker_exit(server, worker):
     """Logs any requests that are still in flight."""
     now = time.time()
-    for env in talisker.wsgi.REQUESTS.values():
-        duration = now - env['start_time']
-        talisker.wsgi.log_response(
-            env,
-            duration=duration,
-            timeout=True,
-        )
+    for wsgi_request in talisker.wsgi.REQUESTS.values():
+        duration = now - wsgi_request.environ['start_time']
+        wsgi_request.log(duration, timeout=True)
 
 
 class GunicornLogger(Logger):

--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -53,7 +53,7 @@ __all__ = [
     'configure_testing',
     'get_client',
     'record_breadcrumb',
-    'report_wsgi_error',
+    'report_wsgi',
     'set_client',
 ]
 
@@ -81,7 +81,7 @@ except ImportError:
     def record_log_breadcrumb(record):
         pass
 
-    def report_wsgi_error(environ, msg=None, **kwargs):
+    def report_wsgi(environ, msg=None, **kwargs):
         return
 
     class TestSentryContext():
@@ -155,12 +155,13 @@ else:
             })
         raven.breadcrumbs.record(processor=processor)
 
-    def report_wsgi_error(environ, msg=None, **kwargs):
+    def report_wsgi(environ, msg=None, response_data=None, **kwargs):
         """Use raven to report error"""
         sentry = get_client()
         # reuse code from Sentry middleware, if a bit unpleasently
         mw = raven.middleware.Sentry(None, sentry)
-        sentry.http_context(mw.get_http_context(environ))
+        http_context = mw.get_http_context(environ)
+        sentry.http_context(http_context)
         if msg is None:
             return sentry.captureException(**kwargs)
         else:

--- a/talisker/testing.py
+++ b/talisker/testing.py
@@ -283,11 +283,11 @@ class TestContext():
         self.sentry_context = talisker.sentry.TestSentryContext(self.dsn)
 
     def start(self):
-        Context.new()
         self.old_statsd = talisker.statsd.get_client.raw_update(
             self.statsd_client)
         talisker.logs.add_talisker_handler(logging.NOTSET, self.handler)
         self.sentry_context.start()
+        Context.new()
 
     def stop(self):
         logging.getLogger().handlers.remove(self.handler)


### PR DESCRIPTION
Renames WSGIResponse to TaliskerWSGIRequest, as it's not really just a response. Moves the logic of request logging/metrics into the class, so more context is available. Later changes will use this extra context to enhance sentry reports.
