### PR TITLE
Sentry logging breadcrumb fixes

### DIFF
--- a/talisker/context.py
+++ b/talisker/context.py
@@ -65,7 +65,7 @@ if future.utils.PY3:
         else:
             early_log(
                 __name__,
-                'error',
+                'warning',
                 'aiocontextvars is installed, but it does not function with '
                 'python {}. Please use python >= 3.5.3 if you wish to use '
                 'talisker with asyncio.'.format(

--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -342,7 +342,6 @@ class StructuredFormatter(logging.Formatter):
             # we never want sentry to capture DEBUG logs in its breadcrumbs, as
             # they may be sensitive
             if record.levelno > logging.DEBUG:
-
                 talisker.sentry.record_log_breadcrumb(record)
 
             if len(record.message) > self.MAX_MSG_SIZE:
@@ -356,7 +355,7 @@ class StructuredFormatter(logging.Formatter):
             s = self._fmt % record.__dict__
 
             # add our structured tags *before* exception info is added
-            structured = getattr(record, '_structured', {})
+            structured = getattr(record, 'extra', {})
             if record.exc_info and 'errno' not in structured:
                 structured.update(get_errno_fields(record.exc_info[1]))
             if structured:

--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -512,6 +512,7 @@ class TaliskerMiddleware():
 
     def __call__(self, environ, start_response):
         Context.new()
+        talisker.sentry.new_context()
         config = talisker.get_config()
         # populate default values
         Context.current.soft_timeout = config.soft_request_timeout

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -187,21 +187,27 @@ def test_logger_collects_raven_breadcrumbs():
 
     fmt = logs.StructuredFormatter()
     with raven.context.Context() as ctx:
-        fmt.format(make_record({'foo': 'bar'}, 'info'))
-        record = make_record({'foo': 'bar'}, 'info')
-        record.levelno = logging.DEBUG
-        record.levelname = 'debug'
+        record = make_record(
+            {
+                'foo': 'bar',
+                'number': 1,
+            },
+            'msg',
+        )
+        record.levelno = logging.INFO
+        record.levelname = 'info'
+        record.funcName = 'func'
         fmt.format(record)
         breadcrumbs = ctx.breadcrumbs.get_buffer()
 
     assert len(breadcrumbs) == 1
-    assert breadcrumbs[0]['message'] == 'info'
+    assert breadcrumbs[0]['message'] == 'msg'
     assert breadcrumbs[0]['level'] == 'info'
     assert breadcrumbs[0]['category'] == 'name'
     assert breadcrumbs[0]['data'] == {
         'foo': 'bar',
-        'lineno': 'lno',
-        'path': 'fn',
+        'location': 'fn:lno:func',
+        'number': '1',
     }
 
 


### PR DESCRIPTION
Ensure that there is an active sentry context by activating it before
each request. Previously, there was no active context for the very first
request a worker served.

Also improves logging breadcrumbs:
 - remove duplicated information
 - condense file/lineno/funcName into one item
 - stringify keys so breadcrumb displays properly

Cleans up the depreacted use of LogRecord._structured