### PR TITLE
Defer sentry reports until after request complete.

### DIFF
--- a/talisker/flask.py
+++ b/talisker/flask.py
@@ -68,9 +68,8 @@ else:
                 talisker.sentry.set_client(client)
 
         def after_request(self, sender, response, *args, **kwargs):
-            # override after_request to not clear context and transaction
-            if self.last_event_id:
-                response.headers['X-Sentry-ID'] = self.last_event_id
+            # override after_request to not clear context and transaction, as
+            # we still need it
             return response
 
     def sentry(app, dsn=None, transport=None, **kwargs):

--- a/talisker/gunicorn.py
+++ b/talisker/gunicorn.py
@@ -31,7 +31,6 @@ from builtins import *  # noqa
 
 from collections import deque
 import logging
-import time
 
 from gunicorn.glogging import Logger
 from gunicorn.app.wsgiapp import WSGIApplication
@@ -115,10 +114,9 @@ def gunicorn_child_exit(server, worker):
 
 def gunicorn_worker_exit(server, worker):
     """Logs any requests that are still in flight."""
-    now = time.time()
-    for wsgi_request in talisker.wsgi.REQUESTS.values():
-        duration = now - wsgi_request.environ['start_time']
-        wsgi_request.log(duration, timeout=True)
+    for rid in list(talisker.wsgi.REQUESTS):
+        request = talisker.wsgi.REQUESTS[rid]
+        request.finish_request(timeout=True)
 
 
 class GunicornLogger(Logger):

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -189,6 +189,8 @@ def request_wrapper(func):
             ctx.metric_host_name = kwargs.pop('metric_host_name', None)
             return func(method, url, **kwargs)
         finally:
+            # some requests errors can cause the context to be lost, and we
+            # should never fail due to this.
             try:
                 del ctx.metric_api_name
                 del ctx.metric_host_name

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -189,8 +189,11 @@ def request_wrapper(func):
             ctx.metric_host_name = kwargs.pop('metric_host_name', None)
             return func(method, url, **kwargs)
         finally:
-            del ctx.metric_api_name
-            del ctx.metric_host_name
+            try:
+                del ctx.metric_api_name
+                del ctx.metric_host_name
+            except Exception:
+                pass
     request._request_wrapper = True
     return request
 

--- a/tests/wsgi_app.py
+++ b/tests/wsgi_app.py
@@ -32,7 +32,6 @@ import logging
 
 
 def application(environ, start_response):
-    environ['SENTRY_ID'] = 'id'
     if environ['PATH_INFO'] == '/_status/check':
         status = '404 Not Found'
     else:


### PR DESCRIPTION
This has several benefits:

1) We have more data when sending the report, i.e. the response status,
   size, headers, duration, etc,

2) The user never sees the latency of sending the sentry report.

3) We can use synchronus sending of the report, which is simpler that
   the default threaded support. We can also use Talisker's requests
   support to get connection pooling, logging and metrics for sending of
   sentry reports.

One consequence of this change is that responses no long includ X-Sentry-Id header as the response is sent before sentry request is generated.

This is not a big problem however, was we tag each sentry report with the request id, so you can still find it easily.