### PR TITLE
Better gunicorn timeout handling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,9 @@ export DEVEL=1
 WORKER ?= sync
 PORT ?= 8000
 TALISKER = $(BIN)/talisker.gunicorn --bind 0.0.0.0:$(PORT) --reload --worker-class $(WORKER) $(ARGS)
+APP ?= application
 run wsgi:
-	$(TALISKER) tests.wsgi_app:application
+	$(TALISKER) tests.wsgi_app:$(APP)
 
 run_multiprocess: ARGS=-w4
 run_multiprocess: run

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
 gunicorn = gunicorn>=19.7.0,<20.0
 raven = raven>=6.4.0,<7.0
 celery = 
-	celery>=3.1.25.0,<5.0
+	celery>=3.1.25.0,<4.4
 	kombu>=3.0.37,<4.5
 django = django>=1.10,<2.0
 prometheus = prometheus-client>=0.2.0,<0.5.0,!=0.4.0,!=0.4.1

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(
             'aiocontextvars==0.2.2;python_version>="3.5" and python_version<"3.7"',
         ],
         celery=[
-            'celery>=3.1.25.0,<5.0',
+            'celery>=3.1.25.0,<4.4',
             'kombu>=3.0.37,<4.5',
         ],
         dev=[

--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -384,22 +384,23 @@ class TaliskerWSGIRequest():
         # b) soft timeout
         # c) manual debugging (TODO)
 
-        soft_timeout = Context.current.soft_timeout
-        try:
-            if self.exc_info:
-                self.send_sentry(metadata)
-            elif soft_timeout > 0 and response_latency > soft_timeout:
-                self.send_sentry(
-                    metadata,
-                    msg='start_response latency exceeded soft timeout',
-                    level='warning',
-                    extra={
-                        'start_response_latency': response_latency,
-                        'soft_timeout': soft_timeout,
-                    },
-                )
-        except Exception:
-            logger.exception('failed to send soft timeout report')
+        if talisker.sentry.enabled:
+            soft_timeout = Context.current.soft_timeout
+            try:
+                if self.exc_info:
+                    self.send_sentry(metadata)
+                elif soft_timeout > 0 and response_latency > soft_timeout:
+                    self.send_sentry(
+                        metadata,
+                        msg='start_response latency exceeded soft timeout',
+                        level='warning',
+                        extra={
+                            'start_response_latency': response_latency,
+                            'soft_timeout': soft_timeout,
+                        },
+                    )
+            except Exception:
+                logger.exception('failed to send soft timeout report')
 
         talisker.clear_context()
         rid = self.environ.get('REQUEST_ID')

--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -65,6 +65,10 @@ __all__ = [
 REQUESTS = {}
 
 
+class RequestTimeout(Exception):
+    pass
+
+
 def talisker_error_response(environ, headers, exc_info):
     """Returns WSGI iterable to be returned as an error response.
 
@@ -89,11 +93,11 @@ def talisker_error_response(environ, headers, exc_info):
             wsgi_environ.append((k, v))
 
     if config.devel:
-        title = 'Request {}: {}'.format(rid, exc)
+        title = '{}: {}'.format(exc_type.__name__, exc)
         lines = traceback.format_exception(*exc_info)
         tb = PreformattedText(''.join(lines), id='traceback')
     else:
-        title = 'Request {}: {}'.format(rid, exc_type.__name__)
+        title = 'Server Error: {}'.format(exc_type.__name__)
 
     content = [
         Content(title, tag='h1', id='title'),
@@ -302,8 +306,10 @@ class TaliskerWSGIRequest():
                 if not self.start_response_called:
                     self.call_start_response()
                 raise
-            except Exception:
+            except Exception as e:
                 self.exc_info = sys.exc_info()
+                if isinstance(e, RequestTimeout):
+                    self.timedout = True
                 # switch to generating an error response
                 self.iter = iter(self.error(self.exc_info))
                 chunk = next(self.iter)
@@ -583,9 +589,11 @@ class TaliskerMiddleware():
 
         try:
             response_iter = self.app(environ, request.start_response)
-        except Exception:
+        except Exception as e:
             # store details for later
             request.exc_info = sys.exc_info()
+            if isinstance(e, RequestTimeout):
+                request.timedout = True
             # switch to generating an error response
             response_iter = request.error(request.exc_info)
         except SystemExit as e:

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -264,7 +264,10 @@ def test_gunicorn_worker_exit(wsgi_env, context):
     request = talisker.wsgi.TaliskerWSGIRequest(wsgi_env, None, [])
     talisker.wsgi.REQUESTS['ID'] = request
 
-    gunicorn.gunicorn_worker_exit(None, None)
+    class worker:
+        pid = 100
+
+    gunicorn.gunicorn_worker_exit(None, worker())
 
     context.assert_log(
         name='talisker.wsgi',
@@ -274,3 +277,5 @@ def test_gunicorn_worker_exit(wsgi_env, context):
             'timeout': True,
         },
     )
+
+    assert len(context.sentry) == 1

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -115,13 +115,14 @@ def test_test_context():
         name=logger.name, msg='bar', level='warning', extra={'b': 2})
 
     with pytest.raises(AssertionError) as exc:
-        ctx.assert_log(name=logger.name, msg='XXX', level='info')
+        ctx.assert_log(
+            name=logger.name, msg='XXX', level='info', extra={"baz": 1})
 
     assert str(exc.value) == textwrap.dedent("""
-        Could not find log out of {0} logs:
-            msg={1}'XXX' (0 matches)
-            level={1}'info' (2 matches)
-            name='test_test_context' (2 matches)
+        Could not find log out of {0} logs.
+        Search terms that could not be found:
+            msg=XXX
+            extra["baz"]=1
     """).strip().format(len(ctx.logs), 'u' if sys.version_info[0] == 2 else '')
 
     with pytest.raises(AssertionError) as exc:

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -255,8 +255,8 @@ def test_wsgi_request_wrap_error_in_iterator(exc_type, run_wsgi, context):
 
     context.assert_log(msg='GET /', extra=extra)
 
-    # check it sent a sentry message
-    assert len(context.sentry) == 1
+    if talisker.sentry.enabled:
+        assert len(context.sentry) == 1
 
 
 def test_wsgi_request_wrap_error_headers_sent(run_wsgi, context):
@@ -497,8 +497,8 @@ def test_middleware_error_before_start_response(
         extra=extra,
     )
 
-    # check it sent a sentry message
-    assert len(context.sentry) == 1
+    if talisker.sentry.enabled:
+        assert len(context.sentry) == 1
 
 
 @pytest.mark.parametrize('exc_type', [
@@ -545,8 +545,8 @@ def test_middleware_error_after_start_response(
         extra=extra,
     )
 
-    # check it sent a sentry message
-    assert len(context.sentry) == 1
+    if talisker.sentry.enabled:
+        assert len(context.sentry) == 1
 
 
 def test_middleware_preserves_file_wrapper(

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -87,7 +87,8 @@ def run_wsgi(wsgi_env, start_response):
     return run
 
 
-def test_error_response_handler(wsgi_env):
+def test_error_response_handler(wsgi_env, config):
+    config['DEVEL'] = 0
     wsgi_env['REQUEST_ID'] = 'REQUESTID'
     wsgi_env['HTTP_ACCEPT'] = 'application/json'
     headers = [('X-VCS-Revision', 'revid')]
@@ -105,7 +106,7 @@ def test_error_response_handler(wsgi_env):
     )
     error = json.loads(body.decode('utf8'))
     assert content_type == 'application/json'
-    assert error['title'] == 'Request REQUESTID: Exception'
+    assert error['title'] == 'Server Error: Exception'
     assert error['id'] == {'Request-Id': 'REQUESTID'}
     assert error['traceback'] == '[traceback hidden]'
     assert error['request_headers'] == {
@@ -136,7 +137,7 @@ def test_error_response_handler_devel(wsgi_env, config):
         exc_info,
     )
     error = json.loads(body.decode('utf8'))
-    assert error['title'] == 'Request REQUESTID: test'
+    assert error['title'] == 'Exception: test'
     assert error['traceback'][0] == 'Traceback (most recent call last):'
     assert error['traceback'][-3] == '    raise Exception(\'test\')'
     assert error['traceback'][-2] == 'Exception: test'
@@ -216,7 +217,11 @@ def test_wsgi_request_wrap_file(run_wsgi, context, tmpdir):
     )
 
 
-def test_wsgi_request_wrap_error(run_wsgi, context):
+@pytest.mark.parametrize('exc_type', [
+    Exception,
+    wsgi.RequestTimeout,
+])
+def test_wsgi_request_wrap_error_in_iterator(exc_type, run_wsgi, context):
     env = {
         'REQUEST_ID': 'REQUESTID',
         'HTTP_ACCEPT': 'application/json',
@@ -227,27 +232,31 @@ def test_wsgi_request_wrap_error(run_wsgi, context):
             return self
 
         def __next__(self):
-            raise Exception('error')
+            raise exc_type('error')
 
     headers, body = run_wsgi(env, body=ErrorGenerator())
     output = b''.join(body)
     error = json.loads(output.decode('utf8'))
 
-    assert error['title'] == 'Request REQUESTID: Exception'
+    assert error['title'] == 'Server Error: ' + exc_type.__name__
 
-    context.assert_log(
-        msg='GET /',
-        extra=dict([
-            ('method', 'GET'),
-            ('path', '/'),
-            ('status', 500),
-            ('duration_ms', 1000.0),
-            ('ip', '127.0.0.1'),
-            ('proto', 'HTTP/1.0'),
-            ('length', len(output)),
-            ('exc_type', 'Exception'),
-        ]),
-    )
+    extra = dict([
+        ('method', 'GET'),
+        ('path', '/'),
+        ('status', 500),
+        ('duration_ms', 1000.0),
+        ('ip', '127.0.0.1'),
+        ('proto', 'HTTP/1.0'),
+        ('length', len(output)),
+        ('exc_type', exc_type.__name__),
+    ])
+    if exc_type is wsgi.RequestTimeout:
+        extra['timeout'] = True
+
+    context.assert_log(msg='GET /', extra=extra)
+
+    # check it sent a sentry message
+    assert len(context.sentry) == 1
 
 
 def test_wsgi_request_wrap_error_headers_sent(run_wsgi, context):
@@ -445,11 +454,15 @@ def test_middleware_sets_header_deadline(wsgi_env, start_response, config):
     assert contexts[0].deadline == datetime_to_timestamp(ts)
 
 
+@pytest.mark.parametrize('exc_type', [
+    Exception,
+    wsgi.RequestTimeout,
+])
 def test_middleware_error_before_start_response(
-        wsgi_env, start_response, context):
+        exc_type, wsgi_env, start_response, context):
 
     def app(environ, _start_response):
-        raise Exception('error')
+        raise exc_type('error')
 
     extra_env = {'ENV': 'VALUE'}
     extra_headers = {'Some-Header': 'value'}
@@ -460,33 +473,44 @@ def test_middleware_error_before_start_response(
     output = b''.join(mw(wsgi_env, start_response))
     error = json.loads(output.decode('utf8'))
 
-    assert error['title'] == 'Request ID: Exception'
+    assert error['title'] == 'Server Error: ' + exc_type.__name__
     assert wsgi_env['ENV'] == 'VALUE'
     assert wsgi_env['REQUEST_ID'] == 'ID'
-    assert start_response.status == '500 Internal Server Error'
-    assert start_response.exc_info[0] is Exception
+    assert start_response.exc_info[0] is exc_type
     assert start_response.headers[:3] == [
         ('Content-Type', 'application/json'),
         ('Some-Header', 'value'),
         ('X-Request-Id', 'ID'),
     ]
 
+    extra = {
+        'status': 500,
+        'exc_type': exc_type.__name__,
+    }
+
+    if exc_type is wsgi.RequestTimeout:
+        extra['timeout'] = True
+
     context.assert_log(
         name='talisker.wsgi',
         msg='GET /',
-        extra={
-            'status': 500,
-            'exc_type': 'Exception',
-        },
+        extra=extra,
     )
 
+    # check it sent a sentry message
+    assert len(context.sentry) == 1
 
+
+@pytest.mark.parametrize('exc_type', [
+    Exception,
+    wsgi.RequestTimeout,
+])
 def test_middleware_error_after_start_response(
-        wsgi_env, start_response, context):
+        exc_type, wsgi_env, start_response, context):
 
     def app(wsgi_env, _start_response):
         _start_response('200 OK', [('Content-Type', 'application/json')])
-        raise Exception('error')
+        raise exc_type('error')
 
     extra_env = {'ENV': 'VALUE'}
     extra_headers = {'Some-Header': 'value'}
@@ -497,7 +521,7 @@ def test_middleware_error_after_start_response(
     output = b''.join(mw(wsgi_env, start_response))
     error = json.loads(output.decode('utf8'))
 
-    assert error['title'] == 'Request ID: Exception'
+    assert error['title'] == 'Server Error: ' + exc_type.__name__
     assert wsgi_env['ENV'] == 'VALUE'
     assert wsgi_env['REQUEST_ID'] == 'ID'
     assert start_response.status == '500 Internal Server Error'
@@ -507,14 +531,22 @@ def test_middleware_error_after_start_response(
         ('X-Request-Id', 'ID'),
     ]
 
+    extra = {
+        'status': 500,
+        'exc_type': exc_type.__name__,
+    }
+
+    if exc_type is wsgi.RequestTimeout:
+        extra['timeout'] = True
+
     context.assert_log(
         name='talisker.wsgi',
         msg='GET /',
-        extra={
-            'status': 500,
-            'exc_type': 'Exception',
-        },
+        extra=extra,
     )
+
+    # check it sent a sentry message
+    assert len(context.sentry) == 1
 
 
 def test_middleware_preserves_file_wrapper(

--- a/tests/wsgi_app.py
+++ b/tests/wsgi_app.py
@@ -29,6 +29,7 @@ from __future__ import absolute_import
 
 import pprint
 import logging
+import time
 
 
 def application(environ, start_response):
@@ -44,6 +45,7 @@ def application(environ, start_response):
     logger.warning('warning')
     logger.error('error')
     logger.critical('critical')
+    time.sleep(10)
     return [output.encode('utf8')]
 
 
@@ -54,3 +56,21 @@ def app404(environ, start_response):
     else:
         start_response('404 Not Found', [])
         return [b'Not Found']
+
+
+def timeout(environ, start_response):
+    time.sleep(1000)
+
+
+def timeout2(environ, start_response):
+    start_response('200 OK', [('content-type', 'text/plain')])
+    time.sleep(1000)
+
+
+def timeout3(environ, start_response):
+    start_response('200 OK', [('content-type', 'text/plain')])
+
+    def i():
+        yield time.sleep(1000)
+
+    return i()

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skipsdist = True
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 usedevelop = True
 deps = -r{toxinidir}/requirements.tests.txt
-commands = py.test -n auto --cov=talisker --no-success-flaky-report
+commands = py.test -v --cov=talisker --no-success-flaky-report
 extras =
     gunicorn
     raven


### PR DESCRIPTION
By raising our own exception in Gunicorn's worker_abort handler, we can
catch and handle it just like any other error. This means we get an
error response, logging, and sentry report for the timeout, which is
a massive improvement.

Also includes a few of drive-by tweaks - disable parallel pytest runs in tox, as it generally confuses things, tweak the error message for assert_log help to reduce noise, and slight tweaks to the title of the default error pages.