### PR TITLE
Support X-Debug header that sends sentry report

### DIFF
--- a/talisker/config.py
+++ b/talisker/config.py
@@ -393,7 +393,7 @@ class Config():
     def is_trusted_addr(self, addr_str):
         if not addr_str:
             return False
-        ip = ip_address(addr_str)
+        ip = ip_address(force_unicode(addr_str))
         return ip.is_loopback or any(
             ip in network for network in self.networks
         )

--- a/talisker/config.py
+++ b/talisker/config.py
@@ -33,7 +33,7 @@ __metaclass__ = type
 
 import collections
 from future.utils import text_to_native_str
-from ipaddress import ip_network
+from ipaddress import ip_network, ip_address
 import os
 import subprocess
 import sys
@@ -389,6 +389,14 @@ class Config():
     @property
     def wsgi_id_header(self):
         return 'HTTP_' + self.id_header.upper().replace('-', '_')
+
+    def is_trusted_addr(self, addr_str):
+        if not addr_str:
+            return False
+        ip = ip_address(addr_str)
+        return ip.is_loopback or any(
+            ip in network for network in self.networks
+        )
 
 
 def parse_config_file(filename):

--- a/talisker/context.py
+++ b/talisker/context.py
@@ -151,6 +151,7 @@ class ContextData():
         self.tracking = defaultdict(Tracker)
         self.soft_timeout = -1
         self.deadline = None
+        self.debug = False
 
     def set_deadline(self, timeout):
         """Set the absolute request deadline."""
@@ -220,6 +221,13 @@ class ContextAPI():
     @request_id.setter
     def request_id(self, _id):
         self.current.request_id = _id
+
+    @property
+    def debug(self):
+        return self.current.debug
+
+    def set_debug(self):
+        self.current.debug = True
 
     def deadline_timeout(self):
         if self.current.deadline is None:

--- a/talisker/endpoints.py
+++ b/talisker/endpoints.py
@@ -82,7 +82,7 @@ def private(f):
     def wrapper(self, request):
         config = talisker.get_config()
         # talisker middleware provides this
-        ip_str = request.environ.get('CLIENT_IP')
+        ip_str = request.environ.get('CLIENT_ADDR')
         if ip_str is None:
             # fallback to werkzeug's handling
             ip_str = force_unicode(request.access_route[-1])

--- a/talisker/endpoints.py
+++ b/talisker/endpoints.py
@@ -32,7 +32,6 @@ from builtins import *  # noqa
 import collections
 from datetime import datetime
 import functools
-from ipaddress import ip_address
 import logging
 import os
 import sys
@@ -82,14 +81,19 @@ def private(f):
     @functools.wraps(f)
     def wrapper(self, request):
         config = talisker.get_config()
-        if not request.access_route:
-            # this means something probably bugged in werkzeug, but let's fail
-            # gracefully
-            return Response('no client ip provided', status='403 Forbidden')
+        # talisker middleware provides this
+        ip_str = request.environ.get('CLIENT_IP')
+        if ip_str is None:
+            # fallback to werkzeug's handling
+            ip_str = force_unicode(request.access_route[-1])
 
-        ip_str = force_unicode(request.access_route[-1])
-        ip = ip_address(ip_str)
-        if ip.is_loopback or any(ip in network for network in config.networks):
+        if ip_str is None:
+            return Response(
+                'no client ip provided',
+                status='403 Forbidden',
+            )
+
+        if config.is_trusted_addr(ip_str):
             return f(self, request)
         else:
             msg = PRIVATE_BODY_RESPONSE_TEMPLATE.format(
@@ -97,6 +101,7 @@ def private(f):
                 force_unicode(request.remote_addr),
                 request.headers.get('x-forwarded-for'))
             return Response(msg, status='403 Forbidden')
+
     return wrapper
 
 

--- a/talisker/testing.py
+++ b/talisker/testing.py
@@ -222,7 +222,9 @@ class LogRecordList(list):
             date, tod, level, name, msg = parsed[:5]
             extra = dict((v.split('=', 1)) for v in parsed[5:])
         except ValueError:
-            raise ValueError("failed to parse logfmt:\n" + '\n'.join(lines))
+            raise AssertionError(
+                "failed to parse logfmt:\n" + '\n'.join(lines)
+            )
 
         # create a minimal LogRecord to search against
         record = logging.LogRecord(

--- a/tests/wsgi_app.py
+++ b/tests/wsgi_app.py
@@ -45,7 +45,6 @@ def application(environ, start_response):
     logger.warning('warning')
     logger.error('error')
     logger.critical('critical')
-    time.sleep(10)
     return [output.encode('utf8')]
 
 


### PR DESCRIPTION
This generate a debug-level sentry report for the request.

As a precaution, the header is only respected from a trusted ip address. This provides a secure way to to targeted diagnostic debugging.

This change also reintroduced the X-Sentry-Id header which had been dropped as part of #496, as I figured out how to include that when possible. It's not possible to do so for soft timeouts, as we don't know until after the request is sent. Nor for errors that occur after headers have been sent. However, the sentry report is tagged with the request id, so it's still addressable.