### PR TITLE
Add EXPLAIN output to sql sentry breadcrumbs

### DIFF
--- a/talisker/config.py
+++ b/talisker/config.py
@@ -129,6 +129,7 @@ class Config():
         'TALISKER_NETWORKS': [],
         'TALISKER_ID_HEADER': 'X-Request-Id',
         'TALISKER_DEADLINE_HEADER': 'X-Request-Deadline',
+        'TALISKER_EXPLAIN_SQL': False,
     }
 
     Metadata = collections.namedtuple(
@@ -262,6 +263,16 @@ class Config():
         The queries are sanitized by not including the bind parameter values.
         """
         return force_int(self[raw_name])
+
+    @config_property('TALISKER_EXPLAIN_SQL')
+    def explain_sql(self, raw_name):
+        """Include EXPLAIN plans in sql sentry breadcrumbs. Defaults to false.
+
+        When enabled, this will issue extra queries to the db when generating
+        sentry reports. The EXPLAIN queries will be quick to execute, as it
+        doesn't actually run the query, but still, caution is advised.
+        """
+        return self.is_active(raw_name)
 
     @config_property('TALISKER_SOFT_REQUEST_TIMEOUT')
     def soft_request_timeout(self, raw_name):

--- a/talisker/postgresql.py
+++ b/talisker/postgresql.py
@@ -136,7 +136,7 @@ class TaliskerConnection(connection):
 
         def processor(data):
             qdata['query'] = self._format_query(query, vars)
-            if self.explain_breadcrumbs:
+            if self.explain_breadcrumbs or talisker.Context.debug:
                 try:
                     cursor = base_connection.cursor()
                     cursor.execute('EXPLAIN ' + query, vars)

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -72,6 +72,7 @@ __all__ = [
 STORAGE = Local()
 STORAGE.sessions = {}
 HOSTS = module_dict()
+DEBUG_HEADER = future.utils.text_to_native_str('X-Debug')
 
 
 def clear():
@@ -169,6 +170,8 @@ def send_wrapper(func):
             deadline = datetime.utcfromtimestamp(Context.current.deadline)
             formatted = deadline.isoformat() + 'Z'
             request.headers[config.deadline_header] = formatted
+        if Context.debug:
+            request.headers[DEBUG_HEADER] = '1'
         try:
             return func(request, **kwargs)
         except Exception as e:

--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -262,6 +262,7 @@ else:
 
         def start(self):
             self.client = get_client()
+            new_context()
             self.orig_remote = self.client.remote
             self.client.set_dsn(self.dsn, DummySentryTransport)
             self.transport = self.client.remote.get_transport()
@@ -432,7 +433,7 @@ def add_talisker_context(data):
 def sql_summary(sql_crumbs, start_time):
 
     def duration(crumb):
-        return float(crumb['data'].get('duration', 0))
+        return float(crumb['data'].get('duration_ms', 0))
 
     sql_crumbs.sort(key=duration, reverse=True)
     sql_time = sum(duration(c) for c in sql_crumbs)
@@ -445,13 +446,14 @@ def sql_summary(sql_crumbs, start_time):
         sql_summary['non_sql_time'] = request_time - sql_time
         sql_summary['total_time'] = request_time
 
-    sql_summary['slowest queries'] = [
-        OrderedDict([
-            ('duration', c['data']['duration']),
+    slowest = []
+    for c in sql_crumbs[:5]:
+        slow = OrderedDict([
+            ('duration_ms', c['data']['duration_ms']),
             ('query', c['data']['query'])]
         )
-        for c in sql_crumbs[:5]
-    ]
+        slowest.append(slow)
+    sql_summary['slowest queries'] = slowest
 
     return sql_summary
 

--- a/tests/flask_app.py
+++ b/tests/flask_app.py
@@ -72,7 +72,7 @@ def logging():
 
 @app.route('/error/')
 def error():
-    conn.execute(select([users]))
+    conn.execute(select([users]).where(users.c.id == 1))
     talisker.requests.get_session().post(
         'http://httpbin.org/post', json={'foo': 'bar'})
     logger.info('halp', extra={'foo': 'bar'})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,6 +61,7 @@ def test_config_defaults():
         debuglog=None,
         colour=False,
         slowquery_threshold=-1,
+        explain_sql=False,
         soft_request_timeout=-1,
         request_timeout=None,
         logstatus=False,
@@ -125,6 +126,11 @@ def test_query_threshold_config():
         {'TALISKER_SLOWQUERY_THRESHOLD': 'garbage'}, slowquery_threshold=-1)
     msg = str(cfg.ERRORS['TALISKER_SLOWQUERY_THRESHOLD'])
     assert msg == "'garbage' is not a valid integer"
+
+
+def test_explain_sql_config():
+    assert_config({'TALISKER_EXPLAIN_SQL': '1'}, explain_sql=True)
+    assert_config({'TALISKER_EXPLAIN_SQL': 'garbage'}, explain_sql=False)
 
 
 def test_request_timeout_config():

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -58,9 +58,9 @@ def cursor(conn):
 
 
 def test_connection_record_slow(conn, context, get_breadcrumbs):
-    query = 'select * from table'
+    query = 'select * from table where id=%s'
     conn._threshold = 0
-    conn._record('msg', query, 10000)
+    conn._record('msg', query, (1,), 10000)
     records = context.logs.filter(name='talisker.slowqueries')
     assert records[0].extra['duration_ms'] == 10000.0
     assert records[0]._trailer == prettify_sql(query)
@@ -69,14 +69,14 @@ def test_connection_record_slow(conn, context, get_breadcrumbs):
 @pytest.mark.skipif(not talisker.sentry.enabled, reason='need raven installed')
 def test_connection_record_fast(conn, context):
     query = 'select * from table'
-    conn._record('msg', query, 0)
+    conn._record('msg', query, None, 0)
     context.assert_not_log(name='talisker.slowqueries')
 
 
 @pytest.mark.skipif(not talisker.sentry.enabled, reason='need raven installed')
 def test_connection_record_breadcrumb(conn, get_breadcrumbs):
     query = 'select * from table'
-    conn._record('msg', query, 1000)
+    conn._record('msg', query, None, 1000)
     breadcrumb = get_breadcrumbs()[0]
     assert breadcrumb['message'] == 'msg'
     assert breadcrumb['category'] == 'sql'

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -223,6 +223,7 @@ def test_metric_hook_registered_endpoint(
 def test_configured_session(context, get_breadcrumbs):
     deadline = time.time() + 10
     expected_deadline = datetime.utcfromtimestamp(deadline).isoformat() + 'Z'
+    Context.set_debug()
     Context.current.deadline = deadline
     session = requests.Session()
     talisker.requests.configure(session)
@@ -242,6 +243,7 @@ def test_configured_session(context, get_breadcrumbs):
     headers = responses.calls[0].request.headers
     assert headers['X-Request-Id'] == 'XXX'
     assert headers['X-Request-Deadline'] == expected_deadline
+    assert headers['X-Debug'] == '1'
     assert context.statsd[0] == 'requests.count.localhost.view:1|c'
     assert context.statsd[1].startswith(
         'requests.latency.localhost.view.200:')

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -44,6 +44,8 @@ from freezegun import freeze_time
 
 from talisker import testing
 
+from tests.conftest import require_module
+
 DATESTRING = '2016-01-02 03:04:05.1234'
 
 
@@ -272,13 +274,13 @@ def test_add_talisker_context():
 @freeze_time(DATESTRING)
 def test_sql_summary_crumb():
     crumbs = [
-        {'category': 'sql', 'data': {'duration': 10.0, 'query': '1'}},
-        {'category': 'sql', 'data': {'duration': 15.0, 'query': '2'}},
-        {'category': 'sql', 'data': {'duration': 13.0, 'query': '3'}},
-        {'category': 'sql', 'data': {'duration': 5.0, 'query': '4'}},
-        {'category': 'sql', 'data': {'duration': 11.0, 'query': '5'}},
-        {'category': 'sql', 'data': {'duration': 7.0, 'query': '6'}},
-        {'category': 'sql', 'data': {'duration': 4.0, 'query': '7'}},
+        {'category': 'sql', 'data': {'duration_ms': 10.0, 'query': '1'}},
+        {'category': 'sql', 'data': {'duration_ms': 15.0, 'query': '2'}},
+        {'category': 'sql', 'data': {'duration_ms': 13.0, 'query': '3'}},
+        {'category': 'sql', 'data': {'duration_ms': 5.0, 'query': '4'}},
+        {'category': 'sql', 'data': {'duration_ms': 11.0, 'query': '5'}},
+        {'category': 'sql', 'data': {'duration_ms': 7.0, 'query': '6'}},
+        {'category': 'sql', 'data': {'duration_ms': 4.0, 'query': '7'}},
     ]
 
     start_time = time.time() - 0.5  # 500ms
@@ -289,13 +291,49 @@ def test_sql_summary_crumb():
         'total_time': 500.0,
         'non_sql_time': 435.0,
         'slowest queries': [
-            {'duration': 15.0, 'query': '2'},
-            {'duration': 13.0, 'query': '3'},
-            {'duration': 11.0, 'query': '5'},
-            {'duration': 10.0, 'query': '1'},
-            {'duration': 7.0, 'query': '6'},
+            {'duration_ms': 15.0, 'query': '2'},
+            {'duration_ms': 13.0, 'query': '3'},
+            {'duration_ms': 11.0, 'query': '5'},
+            {'duration_ms': 10.0, 'query': '1'},
+            {'duration_ms': 7.0, 'query': '6'},
         ],
     }
+
+
+@require_module('psycopg2')
+def test_sql_crumbs_functional(request, postgresql, context):
+    import psycopg2
+    from talisker.postgresql import TaliskerConnection
+
+    table = request.function.__name__
+
+    with psycopg2.connect(postgresql.dsn) as ddl:
+        with ddl.cursor() as cur:
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS {} (
+                id   INTEGER PRIMARY KEY,
+                value TEXT
+                );
+            """.format(table))
+            cur.execute("INSERT INTO {} VALUES (1, 'foo')".format(table))
+
+    cur = TaliskerConnection(postgresql.dsn).cursor()
+
+    q = 'SELECT * FROM {} WHERE id = %s'.format(table)
+    cur.execute(q, (1,))
+    cur.fetchall()
+    talisker.sentry.get_client().captureMessage(table)
+    msg = context.sentry[0]
+    sql_crumbs = [
+        c for c in msg['breadcrumbs']['values'] if c['category'] == 'sql'
+    ]
+    data = sql_crumbs[0]['data']
+    assert data['query'] == talisker.postgresql.prettify_sql(q)
+    assert data['plan'].startswith(
+        'Index Scan using {0}_pkey on {0}'.format(table)
+    )
+    assert 'duration_ms' in data
+    assert 'connection' in data
 
 
 def test_proxy_mixin():

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -301,10 +301,11 @@ def test_sql_summary_crumb():
 
 
 @require_module('psycopg2')
-def test_sql_crumbs_functional(request, postgresql, context):
+def test_sql_crumbs_functional(request, postgresql, context, config):
     import psycopg2
     from talisker.postgresql import TaliskerConnection
 
+    config['TALISKER_EXPLAIN_SQL'] = '1'
     table = request.function.__name__
 
     with psycopg2.connect(postgresql.dsn) as ddl:


### PR DESCRIPTION
Also fixes a bug where the name of the duration field was wrong in tests.