### PR TITLE
Fix unbound local variable on request timeout

### DIFF
--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -454,6 +454,7 @@ class TaliskerAdapter(HTTPAdapter):
         return self._send(request, *args, **kwargs)
 
     def _send(self, request, *args, **kwargs):
+        response = None
         try:
             response = super().send(request, *args, **kwargs)
         except requests.ConnectionError as exc:


### PR DESCRIPTION
This fixes a (quite trivial) unbound var exception when dealing with request timeout.
```
UnboundLocalError: local variable 'response' referenced before assignment
  (...)
  File "requests/sessions.py", line 549, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "talisker/requests.py", line 190, in request
    return func(method, url, **kwargs)
  File "requests/sessions.py", line 502, in request
    resp = self.send(prep, **send_kwargs)
  File "talisker/requests.py", line 173, in send
    return func(request, **kwargs)
  File "requests/sessions.py", line 612, in send
    r = adapter.send(request, **kwargs)
  File "talisker/requests.py", line 446, in send
    return self._send(request, *args, **kwargs)
  File "talisker/requests.py", line 527, in _send
    raise requests.ReadTimeout(request=request, response=response)
```