### PR TITLE
Add support for Python 3.8 and gevent 1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
     - python: 3.5
       env: TOXENV=lint
     - python: 2.7

--- a/requirements.tests.txt
+++ b/requirements.tests.txt
@@ -14,7 +14,7 @@ flaky==3.6.1
 
 # for integration tests
 eventlet==0.25.1
-gevent==1.4.0
+gevent==1.5.0
 # the bottom pin is for limbo test runs, as latest version doesn't work with
 # newer celery versions
 redis>=2.10.6,<=3.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ pg_wheel =
 	psycopg2-binary>=2.7.3.2,<3.0
 asyncio = 
 	aiocontextvars==0.2.2;python_version>="3.5" and python_version<"3.7"
+gevent = gevent>=1.5.0
 
 [options.package_data]
 talisker = logstash/*

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,9 @@ setup(
             'flask>=0.11,<1.2',
             'blinker>=1.4,<2.0',
         ],
+        gevent=[
+            'gevent>=1.5.0',
+        ],
         gunicorn=[
             'gunicorn>=19.7.0,<21.0',
         ],

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -269,6 +269,8 @@ def run_gunicorn_eventlet():
 
 def run_gunicorn_gevent():
     import gevent
+    from talisker.context import _patch_gevent_contextvars
+    _patch_gevent_contextvars()
     # this is taken from gunicorn GeventWorker.patch()
     from gevent import monkey
     if gevent.version_info[0] == 0:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -97,7 +97,6 @@ def test_context_thread():
     t.join()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 7), reason="<py3.7 only")
 def test_context_gevent(request):
     try:
         import gevent

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -53,8 +53,6 @@ def test_gunicorn_sync_worker():
 
 @require_module('gunicorn')
 @require_module('gevent')
-@pytest.mark.skipif(
-    sys.version_info >= (3, 7), reason='geventlet not supported on py37')
 def test_gunicorn_gevent_worker():
     with GunicornProcess(APP, args=['--worker-class=gevent']) as p:
         response = requests.get(p.url('/'))


### PR DESCRIPTION
Fixes #514 

This PR adds support for gevent in versions of python > 3.7 if version of gevent >= 1.5.0