### PR TITLE
Require contexts to be explicitly created.

### DIFF
--- a/talisker/logs.py
+++ b/talisker/logs.py
@@ -40,7 +40,6 @@ import time
 from talisker.context import Context, ContextId
 from talisker.util import (
     get_errno_fields,
-    get_rounded_ms,
     module_cache,
     module_dict,
 )
@@ -238,11 +237,6 @@ class StructuredLogger(logging.Logger):
        e.g. log.info('...', extra={...})
 
     """
-
-    def _log(self, *args, **kwargs):
-        t = time.time()
-        super()._log(*args, **kwargs)
-        Context.track('logging', get_rounded_ms(t))
 
     # sadly, we must subclass and override, rather that use the new
     # setLogRecordFactory() in 3.2+, as that does not pass the extra args

--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -167,8 +167,9 @@ def send_wrapper(func):
         rid = Context.request_id
         if rid and config.id_header not in request.headers:
             request.headers[config.id_header] = rid
-        if Context.current.deadline:
-            deadline = datetime.utcfromtimestamp(Context.current.deadline)
+        ctx_deadline = Context.current().deadline
+        if ctx_deadline:
+            deadline = datetime.utcfromtimestamp(ctx_deadline)
             formatted = deadline.isoformat() + 'Z'
             request.headers[config.deadline_header] = formatted
         if Context.debug:
@@ -187,7 +188,7 @@ def request_wrapper(func):
     """Adds support for metric_name kwarg to session."""
     @functools.wraps(func)
     def request(method, url, **kwargs):
-        ctx = Context.current
+        ctx = Context.current()
         try:
             ctx.metric_api_name = kwargs.pop('metric_api_name', None)
             ctx.metric_host_name = kwargs.pop('metric_host_name', None)
@@ -293,7 +294,7 @@ def record_request(request, response=None, exc=None):
         'view': metadata.get('view', 'unknown'),
     }
 
-    ctx = Context.current
+    ctx = Context.current()
     metric_api_name = getattr(ctx, 'metric_api_name', None)
     metric_host_name = getattr(ctx, 'metric_host_name', None)
     if metric_api_name is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,7 @@ def config(environ):
 
 @pytest.fixture
 def wsgi_env():
+    talisker.Context.new()
     env = {'REMOTE_ADDR': '127.0.0.1'}
     setup_testing_defaults(env)
     return env

--- a/tests/py3_asyncio_context.py
+++ b/tests/py3_asyncio_context.py
@@ -20,16 +20,17 @@ def test_context_asyncio():
             pytest.skip('aiocontextvars not installed')
 
     async def r1():
+        Context.new()
         Context.logging.push(a=1)
         Context.track('test', 1.0)
         assert Context.logging.flat == {'a': 1}
-        assert Context.current.tracking['test'].count == 1
+        assert Context.current().tracking['test'].count == 1
 
         await sub()
 
         # changes made by sub should be visible
         assert Context.logging.flat == {'a': 2}
-        assert Context.current.tracking['test'].count == 2
+        assert Context.current().tracking['test'].count == 2
 
     async def sub():
         # should be same context as r1
@@ -37,14 +38,15 @@ def test_context_asyncio():
         Context.logging.push(a=2)
         Context.track('test', 1.0)
         assert Context.logging.flat == {'a': 2}
-        assert Context.current.tracking['test'].count == 2
+        assert Context.current().tracking['test'].count == 2
 
     async def r2():
         # should be a separate context from r1
+        Context.new()
         Context.logging.push(a=3)
         Context.track('test', 1.0)
         assert Context.logging.flat == {'a': 3}
-        assert Context.current.tracking['test'].count == 1
+        assert Context.current().tracking['test'].count == 1
 
     # ensure we have no context
     loop = asyncio.get_event_loop()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -40,6 +40,7 @@ import requests
 
 from tests.conftest import require_module
 from talisker.testing import GunicornProcess, ServerProcess, request_id
+from talisker.context import Context
 
 APP = 'tests.wsgi_app:application'
 
@@ -151,6 +152,7 @@ def test_celery_basic(celery_signals):
 
     with ServerProcess(cmd) as pr:
         pr.wait_for_output(' ready.', timeout=30)
+        Context.new()
         result = basic_task.delay()
         error_result = error_task.delay()
 

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -166,8 +166,8 @@ next(counter)
 def counter_app(environ, start_response, accumulator=[]):
     start_response('200 OK', [('Content-Type', 'application/json')])
     num = str(next(counter))
-    logs.logging_context.push({num: num})
-    return [json.dumps(logs.logging_context.flat).encode('utf8')]
+    Context.logging.push({num: num})
+    return [json.dumps(Context.logging.flat).encode('utf8')]
 
 
 def test_gunicorn_clears_context():
@@ -260,7 +260,8 @@ def test_gunicorn_prometheus_cleanup(caplog):
 def test_gunicorn_worker_exit(wsgi_env, context):
     wsgi_env['start_time'] = time.time()
     wsgi_env['REQUEST_ID'] = 'ID'
-    Context.current.request_id = 'ID'
+    Context.new()
+    Context.request_id = 'ID'
     request = talisker.wsgi.TaliskerWSGIRequest(wsgi_env, None, [])
     talisker.wsgi.REQUESTS['ID'] = request
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -41,6 +41,7 @@ import calendar
 
 import pytest
 
+from talisker.context import Context
 from talisker import logs
 
 
@@ -76,6 +77,7 @@ def parse_logfmt(log):
 
 
 def test_logging_context_ctx():
+    Context.new()
     with logs.logging_context(a=1):
         assert logs.logging_context.flat == {'a': 1}
         with logs.logging_context(a=2):
@@ -84,6 +86,7 @@ def test_logging_context_ctx():
 
 
 def test_logging_context_push():
+    Context.new()
     logs.logging_context.push(a=1)
     assert logs.logging_context.flat == {'a': 1}
     logs.logging_context.push(a=2)
@@ -96,23 +99,27 @@ def test_logging_context_push():
 
 # b/w compat test
 def test_set_logging_context():
+    Context.new()
     logs.set_logging_context(a=1)
     assert logs.logging_context.flat == {'a': 1}
 
 
 # b/w compat test
 def test_extra_logging():
+    Context.new()
     with logs.extra_logging({'a': 1}):
         assert logs.logging_context.flat == {'a': 1}
 
 
 def test_make_record_no_extra():
+    Context.new()
     logger = logs.StructuredLogger('test')
     record = logger.makeRecord(*record_args())
     assert record._structured == {}
 
 
 def test_make_record_global_extra():
+    Context.new()
     logger = logs.StructuredLogger('test')
     logs.set_global_extra({'a': 1})
     record = logger.makeRecord(*record_args())
@@ -121,6 +128,7 @@ def test_make_record_global_extra():
 
 
 def test_make_record_context_extra():
+    Context.new()
     logger = logs.StructuredLogger('test')
     logs.logging_context.push(a=1)
     record = logger.makeRecord(*record_args())
@@ -129,6 +137,7 @@ def test_make_record_context_extra():
 
 
 def test_make_record_all_extra():
+    Context.new()
     logger = logs.StructuredLogger('test')
     logs.set_global_extra({'a': 1})
     logs.logging_context.push(b=2)
@@ -148,6 +157,7 @@ def test_make_record_extra_renamed():
 
 
 def test_make_record_context_renamed():
+    Context.new()
     logger = logs.StructuredLogger('test')
     logs.set_global_extra({'a': 1})
     logs.logging_context.push(a=2)
@@ -156,6 +166,7 @@ def test_make_record_context_renamed():
 
 
 def test_make_record_ordering():
+    Context.new()
     logger = logs.StructuredLogger('test')
     logs.set_global_extra({'global': 1})
     logs.logging_context.push(context=2)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -174,8 +174,8 @@ def test_metric_hook(context, get_breadcrumbs):
 def test_metric_hook_user_name(context, get_breadcrumbs):
     r = mock_response(view='view')
 
-    Context.current.metric_api_name = 'api'
-    Context.current.metric_host_name = 'service'
+    Context.current().metric_api_name = 'api'
+    Context.current().metric_host_name = 'service'
     talisker.requests.metrics_response_hook(r)
 
     assert context.statsd[0] == 'requests.count.service.api:1|c'
@@ -224,7 +224,7 @@ def test_configured_session(context, get_breadcrumbs):
     deadline = time.time() + 10
     expected_deadline = datetime.utcfromtimestamp(deadline).isoformat() + 'Z'
     Context.set_debug()
-    Context.current.deadline = deadline
+    Context.set_absolute_deadline(deadline)
     session = requests.Session()
     talisker.requests.configure(session)
 
@@ -402,7 +402,8 @@ def test_adapter_adds_default_timeout(send_kwargs):
 
 @freeze_time()
 def test_adapter_respects_context_timeout(send_kwargs):
-    Context.current.set_deadline(500)
+    Context.new()
+    Context.set_relative_deadline(500)
     session = requests.Session()
     adapter = talisker.requests.TaliskerAdapter()
     session.mount('http://name', adapter)
@@ -411,7 +412,8 @@ def test_adapter_respects_context_timeout(send_kwargs):
 
 
 def test_adapter_raises_when_context_deadline_exceeded():
-    Context.current.set_deadline(0)
+    Context.new()
+    Context.set_relative_deadline(0)
     session = requests.Session()
     adapter = talisker.requests.TaliskerAdapter()
     session.mount('http://name', adapter)

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -232,6 +232,7 @@ def test_log_client_override_env(config, context):
 
 
 def test_add_talisker_context():
+    talisker.Context.new()
     data = {
         'tags': {'foo': 'bar'},
         'extra': {

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -185,7 +185,7 @@ def test_wsgi_request_soft_timeout_default(run_wsgi, context):
 
 @pytest.mark.skipif(not talisker.sentry.enabled, reason='need raven installed')
 def test_wsgi_request_soft_explicit(run_wsgi, context):
-    talisker.Context.current.soft_timeout = 100
+    talisker.Context.soft_timeout = 100
     run_wsgi(duration=2)
     msg = context.sentry[0]
     assert msg['message'] == 'Soft Timeout: /'
@@ -451,7 +451,7 @@ def test_middleware_sets_deadlines(wsgi_env, start_response, config):
     contexts = []
 
     def app(environ, _start_response):
-        contexts.append(Context.current)
+        contexts.append(Context.current())
         _start_response('200 OK', [('Content-Type', 'text/plain')])
         return [b'OK']
 
@@ -468,7 +468,7 @@ def test_middleware_sets_header_deadline(wsgi_env, start_response, config):
     contexts = []
 
     def app(environ, _start_response):
-        contexts.append(Context.current)
+        contexts.append(Context.current())
         _start_response('200 OK', [('Content-Type', 'text/plain')])
         return [b'OK']
 


### PR DESCRIPTION
Implicitly creating contexts causes a variety of issues, and was a bit
of a hack when first doing the contextvars work.

This change introduces a NullContext, which is the default unless
you've explicitly created one. This NullContext provides the same API as
a context, but does not store any information.

This fixes a few different issues, from context bleeding and leaking,
through to test fixture issues that clear the context dict.

This is an internal API change, and shouldn't affect users code.