### PR TITLE
Fixed flaky tests in test_context.py

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -146,7 +146,10 @@ def test_context_gevent(request):
     g1 = gevent.spawn(f1)
     g2 = gevent.spawn(f2)
     gevent.joinall([g1, g2], timeout=2)
-
+    # Resetting Context
+    Context.clear()
+    Context.current().request_id = None
+    Context.current().tracking = {}
 
 @pytest.mark.skipif(sys.version_info >= (3, 7), reason="<py3.7 only")
 def test_context_eventlet(request):
@@ -178,7 +181,10 @@ def test_context_eventlet(request):
     pool.spawn(f1)
     pool.spawn(f2)
     pool.waitall()
-
+    # Resetting Context
+    Context.clear()
+    Context.current().request_id = None
+    Context.current().tracking = {}
 
 if future.utils.PY3:
     from tests.py3_asyncio_context import test_context_asyncio  # NOQA


### PR DESCRIPTION
Test `test_context_api` and `test_null_context` are flaky in nature.

TestCase passes consistently in the actual order with command:
```
pytest tests/test_context.py
```

TestCase fails when one randomises the order in `test_context.py` module by using the plugin [pytest-random-order](https://pypi.org/project/pytest-random-order/) with command:
```
pytest tests/test_context.py --random-order-seed=<Insert-Value-Here> -v
```

The victims, `test_context_api` and `test_null_context`, fails in a failing test order because there is at least one test that runs before the victim and “pollutes” the state (e.g., global state: here, it is `Context()`) on which the victim depends. ([Paper](https://taoxie.cs.illinois.edu/publications/esecfse19-ifixflakies.pdf))

After investigation, we found the polluter test to be `test_context_gevent` and `test_context_eventlet`
For `test_context_gevent`: --random-order-seed=795276
For `test_context_eventlet`: --random-order-seed=570036

_Potential Fix_: After the polluters are run, reset the Context() to its initial state so that it does not pollute the victims.

Please let us know if you require the pass and fail logs.

Contributors:
[Yash Saboo](https://github.com/yashsaboo)
[Nirupam K N](https://github.com/Nirupamkn)