### PR TITLE
Send view-name (if available) to sentry with soft timeout messages

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -34,6 +34,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
+          sudo apt update
           cat dependencies.txt | xargs sudo apt install -y
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -194,6 +194,18 @@ def test_wsgi_request_soft_explicit(run_wsgi, context):
     assert msg['extra']['soft_timeout'] == 100
 
 
+@pytest.mark.skipif(not talisker.sentry.enabled, reason='need raven installed')
+def test_wsgi_request_soft_explicit_viewname(run_wsgi, context):
+    talisker.Context.soft_timeout = 100
+    run_wsgi(duration=2, headers=[('X-View-Name', 'viewname')])
+    msg = context.sentry[0]
+    assert msg['message'] == 'Soft Timeout: viewname'
+    assert msg['level'] == 'warning'
+    assert msg['transaction'] == 'viewname'
+    assert msg['extra']['start_response_latency'] == 2000
+    assert msg['extra']['soft_timeout'] == 100
+
+
 def test_wsgi_request_wrap_response(run_wsgi, context):
     headers, body = run_wsgi(body=[b'output', b' ', b'here'])
     output = b''.join(body)


### PR DESCRIPTION
This should make the default grouping of those events in Sentry more
accurate in absence of other attributes like stacktrace in this event.
Particularly for views with url path args.

This changes both the "message" itself and adds a transaction tag/field
to the event if it's not set (it might not be available in this context
for example with Django when the appropriate middleware had already
cleared the transaction name).