### PR TITLE
Make util.Local threadsafe and extend its tests

### DIFF
--- a/talisker/util.py
+++ b/talisker/util.py
@@ -276,7 +276,11 @@ class Local(object):
 
     def _check(self):
         pid = os.getpid()
-        if self._local._pid != pid:
+        if not hasattr(self._local, '_pid'):
+            # In a new thread - just add the missing _pid attr.
+            self._local._pid = pid
+        elif self._local._pid != pid:
+            # In a new process - discard the thread local.
             self._local = threading.local()
             self._local._pid = pid
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -38,6 +38,7 @@ import os
 import requests
 import responses
 import socket
+import threading
 import time
 from future.moves.urllib.parse import urlunsplit
 
@@ -765,6 +766,21 @@ def test_adapter_callsite_retries(mock_urllib3, backends):
         ('http://1.2.3.4:8000/foo', (1.0, 6.0)),
         ('http://1.2.3.4:8001/foo', (1.0, 1.0)),
     ]
+
+
+def test_threadlocal_threading():
+    session = talisker.requests.get_session()
+    thread_results = {'ok': False}
+
+    def f(results):
+        new_session = talisker.requests.get_session()
+        results['ok'] = new_session is not session
+
+    thread = threading.Thread(target=f, args=(thread_results,))
+    thread.start()
+    thread.join(timeout=1.1)
+
+    assert thread_results['ok']
 
 
 def test_threadlocal_forking():


### PR DESCRIPTION
This threading.local wrapper was "forksafe" but didn't have the threading.local's capabilities anymore, due to a bug which wasn't obvious if only hasattr() was used to access its attrs (like in the tests here).