### PR TITLE
Ensure that newer versions of celery can be used

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,8 +53,7 @@ install_requires =
 gunicorn = gunicorn>=19.7.0,<21.0
 raven = raven>=6.4.0,<7.0
 celery =
-	celery>=3.1.25.0,<4.4.7;python_version<"3.6"
-	celery>=3.1.25.0,<=5.0.5;python_version>="3.6"
+	celery>=3.1.25.0,<5.1
 django = django>=1.10,<2.0
 prometheus = prometheus-client>=0.5.0,<0.8.0
 flask = 

--- a/setup.py
+++ b/setup.py
@@ -139,8 +139,7 @@ setup(
             'aiocontextvars==0.2.2;python_version>="3.5" and python_version<"3.7"',
         ],
         celery=[
-            'celery>=3.1.25.0,<4.4.7;python_version<"3.6"',
-            'celery>=3.1.25.0,<=5.0.5;python_version>="3.6"',
+            'celery>=3.1.25.0,<5.1',
         ],
         dev=[
             'logging_tree>=1.7',


### PR DESCRIPTION
No need to need to force older versions of celery when python < 3.6