### PR TITLE
Werkzeug 2 compatibility

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.1
+current_version = 0.21.2
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,8 @@
+0.22.2 (2022-03-28)
+-------------------
+* Add support for newer Werkzeug
+* Pin jinja2 & markupsafe to sensible default for doc testing
+
 0.21.1 (2021-11-10)
 -------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ copyright = u'2021, Canonical Ltd'
 # for |version| and |release|, also used in various other places throughout
 # the built documents.
 # The short X.Y version.
-version = '0.21.1'
+version = '0.21.2'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,2 +1,4 @@
 Sphinx==2.4.4
 docutils==0.16
+jinja2<3.1      # We need an older version due to compatilibility
+markupsafe<2.1  # Needed because of jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ filterwarnings = ignore
 
 [metadata]
 name = talisker
-version = 0.21.1
+version = 0.21.2
 description = A common WSGI stack
 long_description = file: README.rst
 author = Simon Davy

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ packages = talisker
 test_suite = tests
 package_dir = talisker=talisker
 install_requires =
-	Werkzeug>=0.10.4,<1.2
+	Werkzeug>=0.10.4,<2.1
 	statsd>=3.2.1,<4.0
 	requests>=2.18.0,<3.0
 	future>=0.15.2,<=0.18.2

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ setup(
     ),
     include_package_data=True,
     install_requires=[
-        'Werkzeug>=0.10.4,<1.2',
+        'Werkzeug>=0.10.4,<2.1',
         'statsd>=3.2.1,<4.0',
         'requests>=2.18.0,<3.0',
         'future>=0.15.2,<=0.18.2',

--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,6 @@ setup(
     ],
     test_suite='tests',
     url='https://github.com/canonical-ols/talisker',
-    version='0.21.1',
+    version='0.21.2',
     zip_safe=False,
 )

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -42,7 +42,7 @@ from talisker.context import (  # NOQA
     request_timeout,
 )
 
-__version__ = '0.21.1'
+__version__ = '0.21.2'
 __all__ = [
     'initialise',
     'get_config',


### PR DESCRIPTION
Allow a broader range of versions for Werzeug.
Version bumper talisker
Pinnen jinja2 & markupsafe to something sensible so the tests pass 