### PR TITLE
Update the dependencies & the version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.1
+current_version = 0.21.2
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 0.22.2 (2022-03-28)
 -------------------
 * Add support for newer Werkzeug
-* Pin jinja2 & markupsafe to sensible default for doc testing
+* Pin jinja2 & markupsafe to sensible defaults for doc testing
 
 0.21.1 (2021-11-10)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,8 @@
+0.22.2 (2022-03-28)
+-------------------
+* Add support for newer Werkzeug
+* Pin jinja2 & markupsafe to sensible default for doc testing
+
 0.21.1 (2021-11-10)
 -------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ copyright = u'2021, Canonical Ltd'
 # for |version| and |release|, also used in various other places throughout
 # the built documents.
 # The short X.Y version.
-version = '0.21.1'
+version = '0.21.2'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,2 +1,4 @@
 Sphinx==2.4.4
 docutils==0.16
+jinja2<3.1      # We need an older version due to compatilibility
+markupsafe<2.1  # Needed because of jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ filterwarnings = ignore
 
 [metadata]
 name = talisker
-version = 0.21.1
+version = 0.21.2
 description = A common WSGI stack
 long_description = file: README.rst
 author = Simon Davy
@@ -44,7 +44,7 @@ packages = talisker
 test_suite = tests
 package_dir = talisker=talisker
 install_requires =
-	Werkzeug>=0.10.4,<1.2
+	Werkzeug>=0.10.4,<3
 	statsd>=3.2.1,<4.0
 	requests>=2.18.0,<3.0
 	future>=0.15.2,<=0.18.2
@@ -59,7 +59,7 @@ celery =
 django = django>=1.10,<4.0
 prometheus = prometheus-client>=0.5.0,<0.8.0
 flask =
-	flask>=0.11,<1.2
+	flask>=0.11,<3
 	blinker>=1.4,<2.0
 dev =
 	logging_tree>=1.7

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ setup(
             'django>=1.10,<4.0',
         ],
         flask=[
-            'flask>=0.11,<1.2',
+            'flask>=0.11,<3',
             'blinker>=1.4,<2.0',
         ],
         gevent=[
@@ -180,7 +180,7 @@ setup(
     ),
     include_package_data=True,
     install_requires=[
-        'Werkzeug>=0.10.4,<1.2',
+        'Werkzeug>=0.10.4,<3',
         'statsd>=3.2.1,<4.0',
         'requests>=2.18.0,<3.0',
         'future>=0.15.2,<=0.18.2',
@@ -204,6 +204,6 @@ setup(
     ],
     test_suite='tests',
     url='https://github.com/canonical-ols/talisker',
-    version='0.21.1',
+    version='0.21.2',
     zip_safe=False,
 )

--- a/talisker/__init__.py
+++ b/talisker/__init__.py
@@ -42,7 +42,7 @@ from talisker.context import (  # NOQA
     request_timeout,
 )
 
-__version__ = '0.21.1'
+__version__ = '0.21.2'
 __all__ = [
     'initialise',
     'get_config',

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -134,9 +134,9 @@ def test_pass_thru():
 
 def test_status_interface(config):
 
-    # We have this FakeSocket, so we can emulate the gunicorn.socket
-    # environment variable. Is it gunicorn specif and represents a
-    # socket object.
+    # FakeSocket is to emulate a socket object as
+    # used in the gunicorn specific `gunicorn.socket`
+    # environment variable on the WSGI request
     class FakeSocket():
         def __init__(self, ip, port):
             self.ip = ip

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -25,6 +25,8 @@
 import sys
 import subprocess
 
+import gevent
+from packaging import version
 import pytest
 import requests
 
@@ -116,6 +118,8 @@ def test_gunicorn_eventlet_entrypoint():
 
 
 @pytest.mark.skipif(sys.version_info[:2] != (3, 6), reason='python 3.6.only')
+@pytest.mark.skipif(version.parse(gevent.__version__) > version.parse("1.2.0"),
+                    reason="Only a problem on older gevent versions")
 @pytest.mark.timeout(80)
 def test_gunicorn_gevent_entrypoint():
     # this will error in python3.6 without our fix

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -103,7 +103,7 @@ def test_celery_entrypoint():
 
 
 @pytest.mark.skipif(sys.version_info[:2] != (3, 6), reason='python 3.6 only')
-@pytest.mark.timeout(40)
+@pytest.mark.timeout(80)
 def test_gunicorn_eventlet_entrypoint():
     # this will error in python3.6 without our fix
     gunicorn = testing.GunicornProcess(
@@ -116,7 +116,7 @@ def test_gunicorn_eventlet_entrypoint():
 
 
 @pytest.mark.skipif(sys.version_info[:2] != (3, 6), reason='python 3.6.only')
-@pytest.mark.timeout(40)
+@pytest.mark.timeout(80)
 def test_gunicorn_gevent_entrypoint():
     # this will error in python3.6 without our fix
     gunicorn = testing.GunicornProcess(

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -303,6 +303,7 @@ def test_configured_session_connection_error(context, get_breadcrumbs):
         context.statsd[1].endswith('unknown:1|c'),
         context.statsd[1].endswith('EAI_NONAME:1|c'),
         context.statsd[1].endswith('EAI_AGAIN:1|c'),
+        context.statsd[1].endswith('EAI_NODATA:1|c'),
     ))
 
     breadcrumbs = get_breadcrumbs()
@@ -316,6 +317,7 @@ def test_configured_session_connection_error(context, get_breadcrumbs):
             assert any((
                 breadcrumbs[-1]['data']['errno'] == 'EAI_NONAME',
                 breadcrumbs[-1]['data']['errno'] == 'EAI_AGAIN',
+                breadcrumbs[-1]['data']['errno'] == 'EAI_NODATA',
             ))
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -110,10 +110,13 @@ def test_get_errno_fields_dns():
             'strerror': 'nodename nor servname provided, or not known'
         }
     else:
-        assert processed_exc == {
+        assert processed_exc in [{
             'errno': 'EAI_NONAME',
             'strerror': 'Name or service not known'
-        }
+        }, {
+            'errno': 'EAI_NODATA',
+            'strerror': 'No address associated with hostname'
+        }]
 
 
 def test_local_forking():

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -637,14 +637,10 @@ def test_middleware_debug_middleware_error(wsgi_env, start_response, context):
 
     assert start_response.status == '500 INTERNAL SERVER ERROR'
 
-    # The X-XSS-Protection flag is no longer set on newer
-    # versions of werzeug, as they output has changed
-    for header in start_response.headers:
-        if header[0] == 'Content-Type':
-            print(header)
-            assert header[1] == 'text/html; charset=utf-8'
-        if header[0] == 'X-Request-Id':
-            assert header[1] == 'ID'
+    # Werkzeug > 2.0 no longer set the X-XSS-Protection header
+    assert ('Content-Type', 'text/html; charset=utf-8') in \
+        start_response.headers
+    assert ('X-Request-Id', 'ID') in start_response.headers
 
     context.assert_log(name='talisker.wsgi', msg='GET /')
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -636,11 +636,15 @@ def test_middleware_debug_middleware_error(wsgi_env, start_response, context):
     list(mw(wsgi_env, start_response))
 
     assert start_response.status == '500 INTERNAL SERVER ERROR'
-    assert start_response.headers == [
-        ('Content-Type', 'text/html; charset=utf-8'),
-        ('X-XSS-Protection', '0'),
-        ('X-Request-Id', 'ID'),
-    ]
+
+    # The X-XSS-Protection flag is no longer set on newer
+    # versions of werzeug, as they output has changed
+    for header in start_response.headers:
+        if header[0] == 'Content-Type':
+            print(header)
+            assert header[1] == 'text/html; charset=utf-8'
+        if header[0] == 'X-Request-Id':
+            assert header[1] == 'ID'
 
     context.assert_log(name='talisker.wsgi', msg='GET /')
 


### PR DESCRIPTION
* bump version: 0.21.1 → 0.21.2
* Pin jinja2 & markupsafe when doing document testing
* Updated History
* Support newer werkzeug versions (<3)