### PR TITLE
Fix the test prometheus counter

### DIFF
--- a/talisker/endpoints.py
+++ b/talisker/endpoints.py
@@ -108,8 +108,8 @@ def test_counter():
     # Also, isolate in its own registry. Multiprocess mode doesn't really use
     # registries, but it helps keep things separated, which is useful in
     # testing.
-    from prometheus_client import Counter, CollectorRegistry
-    return Counter('test', 'test', registry=CollectorRegistry())
+    from prometheus_client import Counter
+    return Counter('test', 'test')
 
 
 class StandardEndpointMiddleware(object):


### PR DESCRIPTION
When referring to the test_counter, removing the reference to the
registry ensures that it works both with single or multiple workers.