### PR TITLE
Reduce version complexity

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [3.5, 3.6, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,16 +2,10 @@
 Credits
 =======
 
-Development Lead
-----------------
-
 * Simon Davy <simon.davy@canonical.com>
-
-Contributors
-------------
-
 * Maximiliano Bertacchini <maximiliano.bertacchini@canonical.com>
 * Adam Collard <adam.collard@canonical.com>
 * Tom Wardill <tom.wardill@canonical.com>
 * Guillermo Gonzalez <guillermo.gonzalez@canonical.com>
 * Robin Winslow <robin.winslow@canonical.com>
+* Wouter van Bommel <wouter.bommel@canonical.com>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,8 @@
+0.22.3 (2022-  -  )
+-------------------
+* Reduce test complexity by only supporting python versions that
+  come with an ubuntu lts
+
 0.22.2 (2022-03-28)
 -------------------
 * Add support for newer Werkzeug

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ limbo-env: $(LIMBO_REQUIREMENTS)
 	pip install $(TOX_OPTS) -r requirements.limbo.text $(TOX_PACKAGES)
 
 $(VENV): setup.py $(REQUIREMENTS) | $(VENV_PATH)
+	$(BIN)/pip install -U pip
 	$(BIN)/pip install -e .[$(TALISKER_EXTRAS)]
 	$(BIN)/pip install $(subst requirements,-r requirements,$(REQUIREMENTS))
 	ln -sf $(VENV_PATH)/lib/$(shell basename $(PYTHON))/site-packages lib

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint: $(VENV)
 	$(BIN)/flake8 talisker tests
 
 _test: $(VENV)
-	. $(BIN)/activate && $(BIN)/pytest -n auto --timeout=15 --no-success-flaky-report $(ARGS)
+	. $(BIN)/activate && $(BIN)/pytest --timeout=15 --no-success-flaky-report $(ARGS)
 
 TEST_FILES = $(shell find tests -maxdepth 1 -name test_\*.py  | cut -c 7- | cut -d. -f1)
 $(TEST_FILES): $(VENV)

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,8 @@ Python version support
 ----------------------
 
 This release of talisker (0.20.0) will be the last to support python 2.7
+Talisker version >0.20.2 will only support python 3.5, 3.6 and 3.8 as they
+come with ubuntu lts releases.
 
 Quick Start
 -----------

--- a/requirements.tests.txt
+++ b/requirements.tests.txt
@@ -21,7 +21,7 @@ eventlet==0.30.2  # pyup: <0.30.3
 gevent==20.9.0
 # the bottom pin is for limbo test runs, as latest version doesn't work with
 # newer celery versions
-redis>=2.10.6
+redis>=3.2.0
 SQLAlchemy==1.3.13
 # newer versions of celery pin vine versions, however
 # older versions don't. This pin is for limbo test runs for

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,34 +44,43 @@ packages = talisker
 test_suite = tests
 package_dir = talisker=talisker
 install_requires =
-	Werkzeug>=0.10.4,<3
-	statsd>=3.2.1,<4.0
-	requests>=2.18.0,<3.0
-	future>=0.15.2,<=0.18.2
-	contextvars==2.4;python_version>="3.5" and python_version<"3.7"
+	Werkzeug~=1.0;python_version~="3.5"
+	Werkzeug<3;python_version>"3.6"
+	statsd~=3.3;python_version~="3.5"
+	statsd<4;python_version>"3.6"
+	requests~=2.25;python_version~="3.5"
+	requests<3.0;python_version>"3.5"
+	future~=0.18
+	contextvars~=2.4;python_version~="3.5"
 
 [options.extras_require]
 gunicorn = gunicorn>=19.7.0
 raven = raven>=6.4.0
 celery =
-	celery>=3.1.25.0,<4.4.7;python_version<="3.5"
+	celery~=4.4;python_version~="3.5"
 	celery>=4,<5.3;python_version>"3.5"
-django = django>=1.10,<4.0
-prometheus = prometheus-client>=0.5.0,<0.8.0
+django =
+    django~=2.2;python_version~="3.5"
+	django<4;python_version>"3.5"
+prometheus =
+	prometheus-client~=0.7.0;python_version~="3.5"
+	prometheus-client<0.8;python_version>"3.5"
 flask =
-	flask>=0.11,<3
-	blinker>=1.4,<2.0
+	flask~=1.1;python_version~="3.5"
+	flask<3;python_version>"3.5"
+	blinker~=1.5;python_version~="3.5"
+	blinker<2;python_version>"3.5"
 dev =
-	logging_tree>=1.7
-	pygments>=2.2
-	psutil>=5.0
-	objgraph>=3.0
+	logging_tree>=1.9
+	pygments>=2.11
+	psutil>=5.9
+	objgraph>=3.5
 pg =
-	sqlparse>=0.3.1
+	sqlparse>=0.4.2
 	psycopg2>=2.8,<3.0
 asyncio =
-	aiocontextvars==0.2.2;python_version>="3.5" and python_version<"3.7"
-gevent = gevent>=1.5.0
+	aiocontextvars==0.2.2;python_version~="3.5"
+gevent = gevent>=20.9.0
 
 [options.package_data]
 talisker = logstash/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,10 +31,7 @@ classifiers =
 	Topic :: System :: Logging
 	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
-	Programming Language :: Python :: 3.9
-	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: Implementation :: CPython
 
 [options]

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,8 @@ Python version support
 ----------------------
 
 This release of talisker (0.20.0) will be the last to support python 2.7
+Talisker version >0.20.2 will only support python 3.5, 3.6 and 3.8 as they
+come with ubuntu lts releases.
 
 Quick Start
 -----------
@@ -122,10 +124,7 @@ setup(
         'Topic :: System :: Logging',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     description='A common WSGI stack',

--- a/setup.py
+++ b/setup.py
@@ -142,37 +142,41 @@ setup(
     ),
     extras_require=dict(
         asyncio=[
-            'aiocontextvars==0.2.2;python_version>="3.5" and python_version<"3.7"',
+            'aiocontextvars==0.2.2;python_version~="3.5"',
         ],
         celery=[
-            'celery>=3.1.25.0,<4.4.7;python_version<="3.5"',
+            'celery~=4.4;python_version~="3.5"',
             'celery>=4,<5.3;python_version>"3.5"',
         ],
         dev=[
-            'logging_tree>=1.7',
-            'pygments>=2.2',
-            'psutil>=5.0',
-            'objgraph>=3.0',
+            'logging_tree>=1.9',
+            'pygments>=2.11',
+            'psutil>=5.9',
+            'objgraph>=3.5',
         ],
         django=[
-            'django>=1.10,<4.0',
+            'django~=2.2;python_version~="3.5"',
+            'django<4;python_version>"3.5"',
         ],
         flask=[
-            'flask>=0.11,<3',
-            'blinker>=1.4,<2.0',
+            'flask~=1.1;python_version~="3.5"',
+            'flask<3;python_version>"3.5"',
+            'blinker~=1.5;python_version~="3.5"',
+            'blinker<2;python_version>"3.5"',
         ],
         gevent=[
-            'gevent>=1.5.0',
+            'gevent>=20.9.0',
         ],
         gunicorn=[
             'gunicorn>=19.7.0',
         ],
         pg=[
-            'sqlparse>=0.3.1',
+            'sqlparse>=0.4.2',
             'psycopg2>=2.8,<3.0',
         ],
         prometheus=[
-            'prometheus-client>=0.5.0,<0.8.0',
+            'prometheus-client~=0.7.0;python_version~="3.5"',
+            'prometheus-client<0.8;python_version>"3.5"',
         ],
         raven=[
             'raven>=6.4.0',
@@ -180,11 +184,14 @@ setup(
     ),
     include_package_data=True,
     install_requires=[
-        'Werkzeug>=0.10.4,<3',
-        'statsd>=3.2.1,<4.0',
-        'requests>=2.18.0,<3.0',
-        'future>=0.15.2,<=0.18.2',
-        'contextvars==2.4;python_version>="3.5" and python_version<"3.7"',
+        'Werkzeug~=1.0;python_version~="3.5"',
+        'Werkzeug<3;python_version>"3.6"',
+        'statsd~=3.3;python_version~="3.5"',
+        'statsd<4;python_version>"3.6"',
+        'requests~=2.25;python_version~="3.5"',
+        'requests<3.0;python_version>"3.5"',
+        'future~=0.18',
+        'contextvars~=2.4;python_version~="3.5"',
     ],
     keywords=[
         'talisker',

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -171,6 +171,10 @@ def test_celery_sentry(celery_app, context):
     reason='"aiocontextvars is installed, but it does not function with '
     'python 3.5.2.'
 )
+@pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason="doesn't work on python 3.6"
+)
 def test_celery_entrypoint():
     entrypoint = 'talisker.celery'
     subprocess.check_output([entrypoint, 'inspect', '--help'])

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -24,7 +24,6 @@
 
 import logging
 import subprocess
-import sys
 
 import pytest
 
@@ -166,15 +165,7 @@ def test_celery_sentry(celery_app, context):
     assert msg['tags']['request_id'] == request_id
 
 
-@pytest.mark.skipif(
-    sys.version_info <= (3, 5, 3),
-    reason='"aiocontextvars is installed, but it does not function with '
-    'python 3.5.2.'
-)
-@pytest.mark.skipif(
-    sys.version_info < (3, 7),
-    reason="doesn't work on python 3.6"
-)
+@pytest.mark.xfail
 def test_celery_entrypoint():
     entrypoint = 'talisker.celery'
     subprocess.check_output([entrypoint, 'inspect', '--help'])

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -24,6 +24,7 @@
 
 import logging
 import subprocess
+import sys
 
 import pytest
 
@@ -165,6 +166,11 @@ def test_celery_sentry(celery_app, context):
     assert msg['tags']['request_id'] == request_id
 
 
+@pytest.mark.skipif(
+    sys.version_info <= (3, 5, 3),
+    reason='"aiocontextvars is installed, but it does not function with '
+    'python 3.5.2.'
+)
 def test_celery_entrypoint():
     entrypoint = 'talisker.celery'
     subprocess.check_output([entrypoint, 'inspect', '--help'])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -99,6 +99,10 @@ def test_gunicorn_entrypoint():
     reason='"aiocontextvars is installed, but it does not function with '
     'python 3.5.2.'
 )
+@pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason="doesn't work on python 3.6"
+)
 def test_celery_entrypoint():
     try:
         import celery  # noqa

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -94,15 +94,7 @@ def test_gunicorn_entrypoint():
     subprocess.check_output([entrypoint, '--help'])
 
 
-@pytest.mark.skipif(
-    sys.version_info <= (3, 5, 3),
-    reason='"aiocontextvars is installed, but it does not function with '
-    'python 3.5.2.'
-)
-@pytest.mark.skipif(
-    sys.version_info < (3, 7),
-    reason="doesn't work on python 3.6"
-)
+@pytest.mark.xfail
 def test_celery_entrypoint():
     try:
         import celery  # noqa

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -94,6 +94,11 @@ def test_gunicorn_entrypoint():
     subprocess.check_output([entrypoint, '--help'])
 
 
+@pytest.mark.skipif(
+    sys.version_info <= (3, 5, 3),
+    reason='"aiocontextvars is installed, but it does not function with '
+    'python 3.5.2.'
+)
 def test_celery_entrypoint():
     try:
         import celery  # noqa

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py38, py39, py310, docs, lint, minimal_dep_version, no-extras
+envlist = py35, py36, py38, py310, docs, lint, minimal_dep_version, no-extras
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -8,8 +8,6 @@ python =
     3.5: py35,minimal_dep_version
     3.6: py36
     3.8: py38,lint,docs, no-extras
-    3.9: py39
-    3.10: py310
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, py39, py310, docs, lint, minimal_dep_version, no-extras
+envlist = py35, py36, py38, py39, py310, docs, lint, minimal_dep_version, no-extras
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -7,8 +7,7 @@ skipsdist = True
 python =
     3.5: py35,minimal_dep_version
     3.6: py36
-    3.7: py37,lint,docs, no-extras
-    3.8: py38
+    3.8: py38,lint,docs, no-extras
     3.9: py39
     3.10: py310
 
@@ -38,7 +37,7 @@ deps =
 basepython = python3.5
 
 [testenv:no-extras]
-basepython = python3.7
+basepython = python3.8
 extras =
 
 [testenv:lint]
@@ -46,12 +45,12 @@ skip_install = True
 usedevelop = False
 deps = -r{toxinidir}/requirements.lint.txt
 commands = flake8 talisker tests
-basepython = python3.7
+basepython = python3.8
 
 [testenv:docs]
 deps = -r{toxinidir}/requirements.docs.txt
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
-basepython = python3.7
+basepython = python3.8
 
 [testenv:packaging]
 skip_install = True


### PR DESCRIPTION
Reduce supported python versions to those that come with python lts releases

* python3.5 (xenial)
* python3.6 (bionic)
* python3.8 (focal)