### PR TITLE
tune histogram buckets for wsgi and requests latency (milliseconds)

### DIFF
--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -86,7 +86,7 @@ class RequestsMetric:
         labelnames=['host', 'view', 'status'],
         statsd='{name}.{host}.{view}.{status}',
         # predefining these sucks
-        buckets=[4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192],
+        buckets=[50, 100, 500, 1000, 2000, 5000, 7500, float("inf")],
     )
 
     count = talisker.metrics.Counter(

--- a/talisker/wsgi.py
+++ b/talisker/wsgi.py
@@ -128,7 +128,7 @@ class WSGIMetric:
         documentation='Duration of requests served by WSGI',
         labelnames=['view', 'status', 'method'],
         statsd='{name}.{view}.{method}.{status}',
-        buckets=[4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192],
+        buckets=[50, 100, 500, 1000, 2000, 5000, 7500, 10000, float("inf")],
     )
 
     requests = talisker.metrics.Counter(


### PR DESCRIPTION
This is more a exploratory thing, I'm not entirely sure about the correctness.
I based the new values in that we don't usually care if something takes 10 or 50ms, so the first bucket is 50.
the rest of the buckets are based on the same idea and heavily based on our timeouts...which might not be suitable for others(or maybe it is?)