### PR TITLE
Fix spelling of Python 3.5-specific requirements

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt update
           cat dependencies.txt | xargs sudo apt install -y
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
+          pip install 'tox<4' 'tox-gh-actions<3'
       - name: Start redis
         run: sudo systemctl start redis-server
       - name: Setup tox, dependencies, and run tests

--- a/requirements.tests.txt
+++ b/requirements.tests.txt
@@ -25,6 +25,8 @@ eventlet==0.30.2;python_version<"3.10"
 eventlet>0.33;python_version>="3.10"
 gevent==20.9.0;python_version<"3.10"
 gevent>21;python_version>="3.10"
+# ABI change, incompatible with gevent<22.10.2
+greenlet<2;python_version<"3.10"
 # the bottom pin is for limbo test runs, as latest version doesn't work with
 # newer celery versions
 redis>=3.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,9 @@ test_suite = tests
 package_dir = talisker=talisker
 install_requires =
 	Werkzeug~=1.0;python_version~="3.5.0"
-	Werkzeug<3;python_version>"3.6"
+	Werkzeug<3;python_version>="3.6"
 	statsd~=3.3;python_version~="3.5.0"
-	statsd<4;python_version>"3.6"
+	statsd<4;python_version>="3.6"
 	requests~=2.25;python_version~="3.5.0"
 	requests<3.0;python_version>"3.5"
 	future~=0.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,31 +42,31 @@ packages = talisker
 test_suite = tests
 package_dir = talisker=talisker
 install_requires =
-	Werkzeug~=1.0;python_version~="3.5"
+	Werkzeug~=1.0;python_version~="3.5.0"
 	Werkzeug<3;python_version>"3.6"
-	statsd~=3.3;python_version~="3.5"
+	statsd~=3.3;python_version~="3.5.0"
 	statsd<4;python_version>"3.6"
-	requests~=2.25;python_version~="3.5"
+	requests~=2.25;python_version~="3.5.0"
 	requests<3.0;python_version>"3.5"
 	future~=0.18
-	contextvars~=2.4;python_version~="3.5"
+	contextvars~=2.4;python_version>="3.5" and python_version<"3.7"
 
 [options.extras_require]
 gunicorn = gunicorn>=19.7.0
 raven = raven>=6.4.0
 celery =
-	celery~=4.4;python_version~="3.5"
+	celery~=4.4;python_version~="3.5.0"
 	celery>=4,<5.3;python_version>"3.5"
 django =
-    django~=2.2;python_version~="3.5"
+	django~=2.2;python_version~="3.5.0"
 	django<4;python_version>"3.5"
 prometheus =
-	prometheus-client~=0.7.0;python_version~="3.5"
+	prometheus-client~=0.7.0;python_version~="3.5.0"
 	prometheus-client<0.8;python_version>"3.5"
 flask =
-	flask~=1.1;python_version~="3.5"
+	flask~=1.1;python_version~="3.5.0"
 	flask<3;python_version>"3.5"
-	blinker~=1.5;python_version~="3.5"
+	blinker~=1.5;python_version~="3.5.0"
 	blinker<2;python_version>"3.5"
 dev =
 	logging_tree>=1.9
@@ -77,7 +77,7 @@ pg =
 	sqlparse>=0.4.2
 	psycopg2>=2.8,<3.0
 asyncio =
-	aiocontextvars==0.2.2;python_version~="3.5"
+	aiocontextvars==0.2.2;python_version>="3.5.3" and python_version<"3.7"
 gevent = gevent>=20.9.0
 
 [options.package_data]

--- a/setup.py
+++ b/setup.py
@@ -142,10 +142,10 @@ setup(
     ),
     extras_require=dict(
         asyncio=[
-            'aiocontextvars==0.2.2;python_version~="3.5"',
+            'aiocontextvars==0.2.2;python_version>="3.5.3" and python_version<"3.7"',
         ],
         celery=[
-            'celery~=4.4;python_version~="3.5"',
+            'celery~=4.4;python_version~="3.5.0"',
             'celery>=4,<5.3;python_version>"3.5"',
         ],
         dev=[
@@ -155,13 +155,13 @@ setup(
             'objgraph>=3.5',
         ],
         django=[
-            'django~=2.2;python_version~="3.5"',
+            'django~=2.2;python_version~="3.5.0"',
             'django<4;python_version>"3.5"',
         ],
         flask=[
-            'flask~=1.1;python_version~="3.5"',
+            'flask~=1.1;python_version~="3.5.0"',
             'flask<3;python_version>"3.5"',
-            'blinker~=1.5;python_version~="3.5"',
+            'blinker~=1.5;python_version~="3.5.0"',
             'blinker<2;python_version>"3.5"',
         ],
         gevent=[
@@ -175,7 +175,7 @@ setup(
             'psycopg2>=2.8,<3.0',
         ],
         prometheus=[
-            'prometheus-client~=0.7.0;python_version~="3.5"',
+            'prometheus-client~=0.7.0;python_version~="3.5.0"',
             'prometheus-client<0.8;python_version>"3.5"',
         ],
         raven=[
@@ -184,14 +184,14 @@ setup(
     ),
     include_package_data=True,
     install_requires=[
-        'Werkzeug~=1.0;python_version~="3.5"',
+        'Werkzeug~=1.0;python_version~="3.5.0"',
         'Werkzeug<3;python_version>"3.6"',
-        'statsd~=3.3;python_version~="3.5"',
+        'statsd~=3.3;python_version~="3.5.0"',
         'statsd<4;python_version>"3.6"',
-        'requests~=2.25;python_version~="3.5"',
+        'requests~=2.25;python_version~="3.5.0"',
         'requests<3.0;python_version>"3.5"',
         'future~=0.18',
-        'contextvars~=2.4;python_version~="3.5"',
+        'contextvars~=2.4;python_version>="3.5" and python_version<"3.7"',
     ],
     keywords=[
         'talisker',

--- a/setup.py
+++ b/setup.py
@@ -185,9 +185,9 @@ setup(
     include_package_data=True,
     install_requires=[
         'Werkzeug~=1.0;python_version~="3.5.0"',
-        'Werkzeug<3;python_version>"3.6"',
+        'Werkzeug<3;python_version>="3.6"',
         'statsd~=3.3;python_version~="3.5.0"',
-        'statsd<4;python_version>"3.6"',
+        'statsd<4;python_version>="3.6"',
         'requests~=2.25;python_version~="3.5.0"',
         'requests<3.0;python_version>"3.5"',
         'future~=0.18',

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -29,6 +29,7 @@ from werkzeug.wrappers import Response, Request
 import talisker.statsd
 import talisker.endpoints
 from talisker.endpoints import StandardEndpointMiddleware
+from talisker.util import pkg_is_installed
 
 from tests.test_metrics import counter_name
 
@@ -330,6 +331,8 @@ def test_info_workers():
 
 
 def test_info_objgraph():
+    if not pkg_is_installed('objgraph'):
+        pytest.skip('objgraph not installed')
     client = get_client()
     response = client.get('/_status/info/objgraph',
                           environ_overrides={'REMOTE_ADDR': b'127.0.0.1'})

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ python =
 
 [testenv]
 usedevelop = True
-deps = -r{toxinidir}/requirements.tests.txt
+deps =
+    -r{toxinidir}/requirements.tests.txt
+    {toxinidir}
 commands = py.test -v --cov=talisker --no-success-flaky-report
 extras =
     gunicorn


### PR DESCRIPTION
According to PEP 440, `~="3.5"` is equivalent to `>="3.5", =="3.*"` - that is, any 3.x version from 3.5 on.  I don't think that's what was intended in most of these cases, and the effect is that resolvers on recent versions of Python end up pinning to the versions that work on 3.5, which is pretty excessive.

In most of these cases, `~="3.5.0"` is a better spelling, restricting these pins to Python 3.5.x.  The exceptions seem to be `aiocontextvars` and `contextvars`, which were needed in Python 3.5 and 3.6, but aren't needed as of 3.7 since `contextvars` is in the standard library there; I think `>="3.5"` plus `<"3.7"` and similar makes more sense for those cases. (Comments in `talisker.context` indicate that `aiocontextvars` specifically requires at least 3.5.3.)