### PR TITLE
Remove obsolete lgtm integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,14 +13,6 @@ Talisker - an opinionated WSGI app platform
     :target: https://readthedocs.org/projects/talisker/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://img.shields.io/lgtm/grade/python/g/canonical-ols/talisker.svg?logo=lgtm&logoWidth=18
-    :target: https://lgtm.com/projects/g/canonical-ols/talisker/
-    :alt: Python code quality (LGTM)
-
-.. image:: https://img.shields.io/lgtm/alerts/g/canonical-ols/talisker.svg?logo=lgtm&logoWidth=18
-    :target: https://lgtm.com/projects/g/canonical-ols/talisker/
-    :alt: LGTM alerts
-
 Talisker is an enhanced runtime for your WSGI application that aims to provide
 a common operational platform for your python microservices.
 

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,4 +1,0 @@
-extraction:
-  python:
-    python_setup:
-      version: 3

--- a/setup.py
+++ b/setup.py
@@ -45,14 +45,6 @@ Talisker - an opinionated WSGI app platform
     :target: https://readthedocs.org/projects/talisker/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://img.shields.io/lgtm/grade/python/g/canonical-ols/talisker.svg?logo=lgtm&logoWidth=18
-    :target: https://lgtm.com/projects/g/canonical-ols/talisker/
-    :alt: Python code quality (LGTM)
-
-.. image:: https://img.shields.io/lgtm/alerts/g/canonical-ols/talisker.svg?logo=lgtm&logoWidth=18
-    :target: https://lgtm.com/projects/g/canonical-ols/talisker/
-    :alt: LGTM alerts
-
 Talisker is an enhanced runtime for your WSGI application that aims to provide
 a common operational platform for your python microservices.
 

--- a/talisker/statsd.py
+++ b/talisker/statsd.py
@@ -61,7 +61,7 @@ def get_client():
     return client
 
 
-class DummyClient(StatsClient):  # lgtm [py/missing-call-to-init]
+class DummyClient(StatsClient):
     """Mock client for statsd that can collect data when testing."""
     _prefix = ''  # force no prefix
 
@@ -73,7 +73,7 @@ class DummyClient(StatsClient):  # lgtm [py/missing-call-to-init]
         else:
             self.stats = None
 
-    def _send(self, data):  # lgtm [py/inheritance/signature-mismatch]
+    def _send(self, data):
         if self.stats is not None:
             self.stats.append(data)
 


### PR DESCRIPTION
lgtm was shut down at the end of 2022, see
https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

While GitHub offers a similar service, leveraging that is out of scope of this contribution.