### PR TITLE
Prevent prometheus_client deadlocks during signal handling by the gunicorn arbiter

### DIFF
--- a/talisker/requests.py
+++ b/talisker/requests.py
@@ -80,6 +80,7 @@ logger = logging.getLogger('talisker.requests')
 
 class RequestsMetric:
     latency = talisker.metrics.Histogram(
+        _only_workers_prometheus=True,
         name='requests_latency',
         documentation='Duration of http calls via requests library',
         labelnames=['host', 'view', 'status'],
@@ -89,6 +90,7 @@ class RequestsMetric:
     )
 
     count = talisker.metrics.Counter(
+        _only_workers_prometheus=True,
         name='requests_count',
         documentation='Count of http calls via requests library',
         labelnames=['host', 'view'],
@@ -96,6 +98,7 @@ class RequestsMetric:
     )
 
     errors = talisker.metrics.Counter(
+        _only_workers_prometheus=True,
         name='requests_errors',
         documentation='Count of errors in responses via requests library',
         labelnames=['host', 'type', 'view', 'status'],


### PR DESCRIPTION
We have been affected by deadlocks caused by talisker instrumenting the gunicorn main process' logging with sentry and related prometheus metrics. The deadlocks were on a lock in prometheus_client.

So this is a single threaded context in which the main process was sometimes in the middle of incrementing a prometheus counter as a result of sending an event to sentry as a result of gunicorn main process logging an error log about eg. terminating an unresponsive worker. In the middle of that when the global multiprocessing mode prometheus client lock in values.py was held, a signal handler for SIGCHLD was invoked in that main process in response to some other worker terminating. During that signal handling the main process also logs an error message which caused the sentry event and a corresponding prometheus counter update -> deadlock.

So in order to be more careful/conservative with what we do during signal handling, or in this case what we instrument gunicorn to do, this change sets up all of the requests related metrics to not be emitted from the process they were created in (which for these metrics is the gunicorn arbiter if we're running gunicorn).

More details on prometheus client behavior in
https://github.com/prometheus/client_python/pull/1076