### PR TITLE
Stop using TaliskerRequestsTransport

### DIFF
--- a/talisker/sentry.py
+++ b/talisker/sentry.py
@@ -317,9 +317,6 @@ def ensure_talisker_config(kwargs):
     processors = set(kwargs.get('processors') or [])
     kwargs['processors'] = list(default_processors | processors)
 
-    if 'transport' not in kwargs:
-        kwargs['transport'] = TaliskerRequestsTransport
-
     # note: style clash - sentry client api is 'sanitize_keys'
     sanitise_keys = kwargs.get('sanitize_keys', [])
     if sanitise_keys is None:  # flask integration explicitly sets None


### PR DESCRIPTION
At least for now stop using the TaliskerRequestsTransport.

In practice, for flask apps it was not used in the apps/workers because FlaskSentry was explicitly setting a None 'transport' in the client kwargs.

This change makes sure that the same default raven (threaded) transport is used by logging in the main process. This will mitigate the deadlocks described in
https://github.com/prometheus/client_python/pull/1076#issuecomment-2513729120 because there will be no prometheus instrumentation for sentry requests.