### PR TITLE
Add security linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,8 @@ repos:
     rev: v4.6.0
     hooks:
     -   id: check-yaml
+-   repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+    -   id: flake8
+        exclude: ^(tests/django_app/|docs/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,8 @@ repos:
     hooks:
     -   id: flake8
         exclude: ^(tests/django_app/|docs/)
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+    -   id: bandit
+        args: ["--severity-level", "high"]

--- a/scripts/limbo.py
+++ b/scripts/limbo.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
         fname = 'setup.cfg:options.install_requires'
         print_file(
             fname,
-            (Requirement.parse(l) for l in sorted(install_requires)),
+            (Requirement.parse(req) for req in sorted(install_requires)),
         )
 
     for extra, requires in sorted(extras_require.items()):
@@ -90,7 +90,7 @@ if __name__ == '__main__':
             fname = 'setup.cfg:options.extras_require:' + extra
             print_file(
                 fname,
-                (Requirement.parse(l) for l in sorted(requires)),
+                (Requirement.parse(req) for req in sorted(requires)),
             )
 
     for filename in args.requirements:

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
             'talisker=talisker:run_gunicorn[gunicorn]',
             'talisker.run=talisker:run',
             'talisker.gunicorn=talisker:run_gunicorn[gunicorn]',
-            'talisker.gunicorn.eventlet=talisker:run_gunicorn_eventlet[gunicorn]',
+            'talisker.gunicorn.eventlet=talisker:run_gunicorn_eventlet[gunicorn]',  # noqa: E501
             'talisker.gunicorn.gevent=talisker:run_gunicorn_gevent[gunicorn]',
             'talisker.celery=talisker:run_celery[celery]',
             'talisker.help=talisker:run_help',
@@ -135,7 +135,7 @@ setup(
     ),
     extras_require=dict(
         asyncio=[
-            'aiocontextvars==0.2.2;python_version>="3.5.3" and python_version<"3.7"',
+            'aiocontextvars==0.2.2;python_version>="3.5.3" and python_version<"3.7"',  # noqa: E501
         ],
         celery=[
             'celery~=4.4;python_version~="3.5.0"',
@@ -162,7 +162,7 @@ setup(
         ],
         gunicorn=[
             'gunicorn>=19.7.0;python_version>"3.6"',
-            'gunicorn>=19.7.0,<21.0;python_version>="3.5" and python_version<"3.8"',
+            'gunicorn>=19.7.0,<21.0;python_version>="3.5" and python_version<"3.8"',  # noqa: E501
         ],
         pg=[
             'sqlparse>=0.4.2',

--- a/talisker/postgresql.py
+++ b/talisker/postgresql.py
@@ -133,7 +133,7 @@ class TaliskerConnection(connection):
                 try:
                     cursor = base_connection.cursor()
                     cursor.execute('EXPLAIN ' + query, vars)
-                    plan = '\n'.join(l[0] for l in cursor.fetchall())
+                    plan = '\n'.join(row[0] for row in cursor.fetchall())
                     qdata['plan'] = plan
                 except Exception as e:
                     qdata['plan'] = 'could not explain query: ' + str(e)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -335,7 +335,7 @@ def test_coloured_formatter():
 
 def assert_output_includes_message(err, msg):
     lines = err.split('\n')
-    assert all(parse_logfmt(l) for l in lines if l)
+    assert all(parse_logfmt(line) for line in lines if line)
     assert msg in err
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ skipsdist = True
 python =
     3.5: py35,minimal_dep_version
     3.6: py36
-    3.8: py38,lint,docs, no-extras
+    3.8: py38,docs, no-extras
     3.10: py310
-    3.12: py312
+    3.12: py312,lint
 
 [testenv]
 usedevelop = True
@@ -44,10 +44,9 @@ extras =
 
 [testenv:lint]
 skip_install = True
-usedevelop = False
-deps = -r{toxinidir}/requirements.lint.txt
-commands = flake8 talisker tests
-basepython = python3.8
+deps = pre-commit
+commands = pre-commit run --all-files
+basepython = python3.12
 
 [testenv:docs]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,10 @@ deps = pre-commit
 commands = pre-commit run --all-files
 basepython = python3.12
 
+[testenv:audit]
+deps = pip-audit
+commands = pip-audit
+
 [testenv:docs]
 deps =
     -r{toxinidir}/requirements.docs.txt


### PR DESCRIPTION
- fix linter setup to use pre-commit for all linters
- add bandit (SAST scanner)
- add pip-audit (dependency scanner)

This has been done on request by the Canonical security team.
